### PR TITLE
Added "Default" Standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- "Default" standard option that allows PHPCS to decide which standard to use.
 
 ## [0.2.0] - 2021-02-12
 ### Added

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
           "description": "The coding standard that should be used by PHPCS.",
           "enum": [
             "Disabled",
+            "Default",
             "PEAR",
             "MySource",
             "Squiz",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -5,6 +5,7 @@ import { TextDocument, Uri, workspace as vsCodeWorkspace } from 'vscode';
  */
 export enum StandardType {
     Disabled = 'Disabled',
+    Default = 'Default',
     PEAR = 'PEAR',
     MySource = 'MySource',
     Squiz = 'Squiz',

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -1,5 +1,6 @@
 import { ChildProcess, spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import { CancellationToken, Disposable } from 'vscode';
+import { StandardType } from '../configuration';
 import { ReportFiles } from './report-files';
 import { Request } from './request';
 import { ReportType, Response } from './response';
@@ -138,9 +139,13 @@ export class Worker {
             '--report=' + this.getReportFile(request.type),
             // We want to reserve error exit codes for actual errors in the PHPCS execution since errors/warnings are expected.
             '--runtime-set', 'ignore_warnings_on_exit', '1',
-            '--runtime-set', 'ignore_errors_on_exit', '1',
-            '--standard=' + request.options.standard
+            '--runtime-set', 'ignore_errors_on_exit', '1'
         ];
+
+        // Only set the standard when the user has selected one.
+        if (request.options.standard !== StandardType.Default) {
+            processArguments.push('--standard=' + request.options.standard);
+        }
 
         const processOptions: SpawnOptionsWithoutStdio = {};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added a changelog entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

As suggested by @dhrrgn in #1, this PR adds a "Default" option to `phpCodeSniffer.standard`. This will cause no `--standard` to be passed so that [PHPCS can use its own default](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file).

Closes #1.

### How to test the changes in this Pull Request:

1. Open a project that has a configuration file.
2. Set `phpCodeSniffer.standard` as `"Custom"` and `phpCodeSniffer.standardCustom` as the configuration file's path.
3. Intentionally create a problem for reference.
4. Set `phpCodeSniffer.standard` as `"Default"` and erase `phpCodeSniffer.standardCustom`.
5. Note that PHPCS is using the same standard still and the problem created in step 3 is still present.
