### PR TITLE
Fixed Custom Report Paths For Package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Custom PHPCS report paths in package.
 
 ## [0.3.0] - 2021-02-16
 ### Added

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "vscode": "^1.50.0"
   },
   "main": "dist/extension.js",
+  "extensionKind": [ "workspace" ],
   "activationEvents": [
     "onLanguage:php"
   ],

--- a/src/phpcs-report/report-files.ts
+++ b/src/phpcs-report/report-files.ts
@@ -12,13 +12,13 @@ const CodeActionReport = require('../../phpcs-reports/CodeAction.php');
 const FormatReport = require('../../phpcs-reports/Format.php');
 
 export const Dependencies = {
-    VSCodeFile: path.resolve(__dirname, '..', VSCodeFile),
-    VSCodeFixer: path.resolve(__dirname, '..', VSCodeFixer),
-    VSCodeReport: path.resolve(__dirname, '..', VSCodeReport),
+    VSCodeFile: path.resolve(__dirname, '..', 'dist', VSCodeFile),
+    VSCodeFixer: path.resolve(__dirname, '..', 'dist', VSCodeFixer),
+    VSCodeReport: path.resolve(__dirname, '..', 'dist', VSCodeReport),
 }
 
 export const ReportFiles = {
-    Diagnostic: path.resolve(__dirname, '..', DiagnosticReport),
-    CodeAction: path.resolve(__dirname, '..', CodeActionReport),
-    Format: path.resolve(__dirname, '..', FormatReport),
+    Diagnostic: path.resolve(__dirname, '..', 'dist', DiagnosticReport),
+    CodeAction: path.resolve(__dirname, '..', 'dist', CodeActionReport),
+    Format: path.resolve(__dirname, '..', 'dist', FormatReport),
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
 	"compilerOptions": {
         "rootDir": "src",
 		"outDir": "dist",
-		"target": "ES2017",
-		"module": "CommonJS",
+		"target": "es2017",
+		"module": "commonjs",
 		"lib": [ "ES2017" ],
 		"sourceMap": true,
 		"noImplicitAny": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const config = {
         path: path.resolve(__dirname, 'dist'),
         filename: 'extension.js',
         libraryTarget: 'commonjs2',
+        devtoolModuleFilenameTemplate: "../[resource-path]",
     },
     devtool: 'source-map',
     externals: {


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Since the package lives in `dist` we need to ensure that the paths being used in the `Worker` reference the files correctly. This PR corrects the report paths and changes a few other elements of the build process to ensure that the marketplace extension package works correctly.

### How to test the changes in this Pull Request:

1. Run `vsce package` in the directory
2. Install the extension from the generated package
3. Ensure package works
