### PR TITLE
Automatic `vendor/bin/phpcs` Discovery

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,5 +19,13 @@
     "rules": {
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/ban-ts-comment": "off"
-    }
+    },
+    "overrides": [
+        {
+            "files": [ "src/__mocks__/vscode.ts" ],
+            "rules": {
+                "@typescript-eslint/no-explicit-any": "off"
+            }
+        }
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Automatically attempt to find a `vendor/bin/phpcs` file when `phpCodeSniffer.autoExecutable` is enabled.
 
 ## [0.3.1] - 2021-02-16
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -33,9 +33,15 @@
     "configuration": {
       "title": "PHP_CodeSniffer",
       "properties": {
+        "phpCodeSniffer.autoExecutable": {
+          "type": "boolean",
+          "markdownDescription": "Attempts to find `vendor/bin/phpcs` in the file's directory and parent directories before falling back to `#phpCodeSniffer.executable#`.",
+          "default": false,
+          "scope": "resource"
+        },
         "phpCodeSniffer.executable": {
           "type": "string",
-          "description": "The path to the PHPCS executable we want to use.",
+          "markdownDescription": "The path to the PHPCS executable we want to use when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
           "default": "phpcs",
           "scope": "machine-overridable"
         },
@@ -55,6 +61,7 @@
           ],
           "enumDescriptions": [
             "Disables the PHP_CodeSniffer extension's linting.",
+            "Allows PHPCS to decide the coding standard.",
             "Uses the PEAR coding standard.",
             "Uses the MySource coding standard.",
             "Uses the Squiz coding standard.",
@@ -66,7 +73,6 @@
         },
         "phpCodeSniffer.standardCustom": {
           "type": "string",
-          "description": "The custom coding standard to use if `phpcsCodeSniffer.standard` is set to 'Custom'.",
           "markdownDescription": "The custom coding standard to use if `#phpCodeSniffer.standard#` is set to 'Custom'.",
           "default": "",
           "scope": "window"

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,8 +1,15 @@
-const Uri = jest.fn().mockImplementation(() => {
+const Uri: any = jest.fn().mockImplementation(() => {
     return {
-        fsPath: 'test/path.php'
+        scheme: 'file',
+        authority: '',
+        path: 'test/file/path.php',
+        query: '',
+        fragment: '',
+        fsPath: 'test/file/path.php',
+        toString: jest.fn()
     };
 });
+Uri.joinPath = jest.fn();
 
 const MockTextDocument = jest.fn().mockImplementation(() => {
     return {
@@ -107,7 +114,10 @@ const workspace = {
     onDidChangeConfiguration: jest.fn(),
     onDidChangeWorkspaceFolders: jest.fn(),
     getWorkspaceFolder: jest.fn(),
-    getConfiguration: jest.fn()
+    getConfiguration: jest.fn(),
+    fs: {
+        stat: jest.fn()
+    }
 };
 
 const languages = {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -110,6 +110,16 @@ const TextEdit = jest.fn().mockImplementation((range, newContent) => {
     return { range, newContent };
 });
 
+class FileSystemError extends Error {
+    public readonly code: string;
+
+    public constructor(messageOrUri: string | typeof Uri) {
+        super(messageOrUri.toString());
+
+        this.code = '';
+    }
+}
+
 const workspace = {
     onDidChangeConfiguration: jest.fn(),
     onDidChangeWorkspaceFolders: jest.fn(),
@@ -139,6 +149,7 @@ export {
     CodeAction,
     CodeActionKind,
     TextEdit,
+    FileSystemError,
     workspace,
     languages,
 };

--- a/src/__tests__/configuration.spec.ts
+++ b/src/__tests__/configuration.spec.ts
@@ -1,5 +1,5 @@
-import { TextDocument, workspace } from 'vscode';
-import { MockTextDocument } from '../__mocks__/vscode';
+import { TextDocument, workspace, Uri as vsCodeUri } from 'vscode';
+import { MockTextDocument, Uri } from '../__mocks__/vscode';
 import { mocked } from 'ts-jest/utils';
 import { Configuration, StandardType } from '../configuration';
 
@@ -7,9 +7,41 @@ describe('Configuration', () => {
     let mockDocument: TextDocument;
     let configuration: Configuration;
 
+    beforeAll(() => {
+        // Create a mock implementation that can create joined paths.
+        mocked(Uri.joinPath).mockImplementation((uri: vsCodeUri, ...pathSegments: string[]) => {
+            const uriSegments = uri.path.split('/');
+
+            for (const seg of pathSegments) {
+                if (seg === '.') {
+                    continue;
+                }
+
+                if (seg === '..') {
+                    uriSegments.pop();
+                    continue;
+                }
+
+                uriSegments.push(seg);
+            }
+
+            const path = uriSegments.join('/');
+            return {
+                path: path,
+                fsPath: path,
+                toString: () => path
+            };
+        });
+    });
+
     beforeEach(() => {
         mockDocument = new MockTextDocument();
         configuration = new Configuration(workspace);
+    });
+
+    afterEach(() => {
+        mocked(workspace.getConfiguration).mockClear();
+        mocked(workspace.getWorkspaceFolder).mockClear();
     });
 
     it('should read and cache configuration for document', async () => {
@@ -20,6 +52,7 @@ describe('Configuration', () => {
             switch (key) {
                 case 'standard': return StandardType.Disabled;
                 case 'executable': return 'test.exec';
+                case 'autoExecutable': return false;
             }
 
             fail('An unexpected configuration key of ' + key + ' was received.')
@@ -31,7 +64,57 @@ describe('Configuration', () => {
         expect(result).toMatchObject({
             executable: 'test.exec',
             standard: StandardType.Disabled,
-            workingDirectory: 'test/path.php'
+            workingDirectory: 'test/file'
+        });
+
+        // Make sure that a subsequent fetch loads a cached instance.
+        const cached = await configuration.get(mockDocument);
+
+        expect(workspace.getConfiguration).toHaveBeenCalledTimes(1);
+        expect(cached).toMatchObject(result);
+    });
+
+    it('should read filesystem for executable when enabled', async () => {
+        const mockConfiguration = { get: jest.fn() };
+        mocked(workspace).getConfiguration.mockReturnValue(mockConfiguration as never);
+
+        const workspaceUri = new Uri();
+        workspaceUri.path = 'test';
+        workspaceUri.fsPath = 'test';
+        mocked(workspace).getWorkspaceFolder.mockReturnValue({ uri: workspaceUri } as never);
+
+        // We will traverse from the file directory up.
+        mocked(workspace.fs.stat).mockImplementation((uri) => {
+            switch (uri.path) {
+                case 'test/file/vendor/bin/phpcs': return Promise.reject(new Error('No file found'));
+                case 'test/vendor/bin/phpcs': {
+                    const ret = new Uri();
+                    ret.path = 'test';
+                    ret.fsPath = 'test';
+                    return Promise.resolve(ret);
+                }
+            }
+
+            throw new Error('Invalid path: ' + uri.path);
+        });
+
+        mockConfiguration.get.mockImplementation((key) => {
+            switch (key) {
+                case 'standard': return StandardType.Disabled;
+                case 'executable': return 'test.exec';
+                case 'autoExecutable': return true;
+            }
+
+            fail('An unexpected configuration key of ' + key + ' was received.')
+        });
+
+        const result = await configuration.get(mockDocument);
+
+        expect(workspace.getConfiguration).toHaveBeenCalledWith('phpCodeSniffer', mockDocument);
+        expect(result).toMatchObject({
+            executable: 'test/vendor/bin/phpcs',
+            standard: StandardType.Disabled,
+            workingDirectory: 'test'
         });
 
         // Make sure that a subsequent fetch loads a cached instance.

--- a/src/__tests__/configuration.spec.ts
+++ b/src/__tests__/configuration.spec.ts
@@ -1,4 +1,4 @@
-import { TextDocument, workspace, Uri as vsCodeUri } from 'vscode';
+import { TextDocument, workspace, Uri as vsCodeUri, FileSystemError } from 'vscode';
 import { MockTextDocument, Uri } from '../__mocks__/vscode';
 import { mocked } from 'ts-jest/utils';
 import { Configuration, StandardType } from '../configuration';
@@ -86,7 +86,7 @@ describe('Configuration', () => {
         // We will traverse from the file directory up.
         mocked(workspace.fs.stat).mockImplementation((uri) => {
             switch (uri.path) {
-                case 'test/file/vendor/bin/phpcs': return Promise.reject(new Error('No file found'));
+                case 'test/file/vendor/bin/phpcs': return Promise.reject(new FileSystemError(uri));
                 case 'test/vendor/bin/phpcs': {
                     const ret = new Uri();
                     ret.path = 'test';

--- a/src/__tests__/configuration.spec.ts
+++ b/src/__tests__/configuration.spec.ts
@@ -12,7 +12,7 @@ describe('Configuration', () => {
         configuration = new Configuration(workspace);
     });
 
-    it('should read and cache configuration for document', () => {
+    it('should read and cache configuration for document', async () => {
         const mockConfiguration = { get: jest.fn() };
         mocked(workspace).getConfiguration.mockReturnValue(mockConfiguration as never);
 
@@ -25,7 +25,7 @@ describe('Configuration', () => {
             fail('An unexpected configuration key of ' + key + ' was received.')
         });
 
-        const result = configuration.get(mockDocument);
+        const result = await configuration.get(mockDocument);
 
         expect(workspace.getConfiguration).toHaveBeenCalledWith('phpCodeSniffer', mockDocument);
         expect(result).toMatchObject({
@@ -35,7 +35,7 @@ describe('Configuration', () => {
         });
 
         // Make sure that a subsequent fetch loads a cached instance.
-        const cached = configuration.get(mockDocument);
+        const cached = await configuration.get(mockDocument);
 
         expect(workspace.getConfiguration).toHaveBeenCalledTimes(1);
         expect(cached).toMatchObject(result);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,4 @@
-import { TextDocument, Uri, workspace as vsCodeWorkspace } from 'vscode';
+import { FileSystemError, TextDocument, Uri, workspace as vsCodeWorkspace } from 'vscode';
 
 /**
  * An enum describing the values in the `phpcsCodeSniffer.standard` configuration.
@@ -147,6 +147,11 @@ export class Configuration {
                     workingDirectory = dir.fsPath;
                     break;
                 } catch (e) {
+                    // Only errors indicating from the filesystem are relevant.
+                    if (!(e instanceof FileSystemError)) {
+                        throw e;
+                    }
+
                     // Stop once we reach the workspace folder.
                     if (dir.toString() === workspaceFolder.toString()) {
                         break;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,6 +15,23 @@ export enum StandardType {
 }
 
 /**
+ * An interface describing the configuration parameters we can read from the filesystem.
+ */
+interface ParamsFromFilesystem {
+    workingDirectory: string;
+    executable?: string;
+}
+
+/**
+ * An interface describing the configuration parameters we can read from the workspace configuration.
+ */
+interface ParamsFromConfiguration {
+    standard: string;
+    autoExecutable: boolean;
+    executable: string;
+}
+
+/**
  * An interface descirinb the shape of a document's configuration.
  */
 export interface DocumentConfiguration {
@@ -63,22 +80,25 @@ export class Configuration {
      *
      * @param {TextDocument} document The document we want to fetch the config for.
      */
-    public get(document: TextDocument): Promise<DocumentConfiguration> {
+    public async get(document: TextDocument): Promise<DocumentConfiguration> {
         let config = this.cache.get(document.uri);
         if (config) {
-            return Promise.resolve(config);
+            return config;
         }
 
-        // Read the configuration and cache it to avoid doing so again.
-        const read = this.readConfiguration(document);
+        // Read the configuration and filesystem to build our document's configuration.
+        const fromConfig = this.readConfiguration(document);
+        const fromFilesystem = await this.readFilesystem(document, fromConfig.autoExecutable);
+
+        // Build and cache the document configuration to save time later.
         config = {
-            workingDirectory: this.inferWorkingDirectory(document),
-            executable: read.executable,
-            standard: read.standard
+            workingDirectory: fromFilesystem.workingDirectory,
+            executable: fromFilesystem.executable ?? fromConfig.executable,
+            standard: fromConfig.standard
         };
         this.cache.set(document.uri, config);
 
-        return Promise.resolve(config);
+        return config;
     }
 
     /**
@@ -89,11 +109,57 @@ export class Configuration {
     }
 
     /**
+     * Reads the configuration for a document from the filesystem and resolves it.
+     *
+     * @param {TextDocument} document The document to read.
+     * @param {boolean} findExecutable Indicates whether or not we should perform an executable search.
+     */
+    private async readFilesystem(document: TextDocument, findExecutable: boolean): Promise<ParamsFromFilesystem> {
+        // The top-level folder will serve as the endpoint for our traversal.
+        const workspaceFolder = this.getWorkspaceFolder(document);
+
+        // By default the working directory will be the workspace folder for the document.
+        let workingDirectory = workspaceFolder.fsPath;
+
+        // When desired we will attempt to find a PHPCS executable by scanning for a `vendor/bin/phpcs` file
+        // in the document's directory. If that fails we will attempt the same in each parent directory
+        // until we reach the workspace directory.
+        let executable: string|undefined = undefined;
+        if (findExecutable) {
+            // Start in the document's directory.
+            let dir: Uri = Uri.joinPath(document.uri, '..');
+            while (dir) {
+                const phpcsPath = Uri.joinPath(dir, 'vendor/bin/phpcs');
+                try {
+                    await this.workspace.fs.stat(phpcsPath);
+
+                    // We've found an executable.
+                    executable = phpcsPath.fsPath;
+
+                    // The working directory should be considered the directory for the project containing PHPCS.
+                    workingDirectory = dir.fsPath;
+                    break;
+                } catch (e) {
+                    // Stop once we reach the workspace folder.
+                    if (dir.toString() === workspaceFolder.toString()) {
+                        break;
+                    }
+
+                    dir = Uri.joinPath(dir, '..');
+                    continue;
+                }
+            }
+        }
+
+        return { workingDirectory, executable };
+    }
+
+    /**
      * Reads the configuration for a document and returns the relevant data.
      *
      * @param {TextDocument} document The document to read.
      */
-    private readConfiguration(document: TextDocument): Pick<DocumentConfiguration, 'standard'|'executable'> {
+    private readConfiguration(document: TextDocument): ParamsFromConfiguration {
         const config = this.workspace.getConfiguration('phpCodeSniffer', document);
         if (!config) {
             throw new Error('The extension has no configuration.');
@@ -107,32 +173,37 @@ export class Configuration {
             standard = StandardType.Disabled;
         }
 
-        const executable = config.get<string>('executable');
-        if (!executable) {
-            throw new Error('The extension has no worker configured');
+        const autoExecutable = config.get<boolean>('autoExecutable');
+        if (autoExecutable === undefined) {
+            throw new Error('The extension has an invalid `autoExecutable` configuration.');
         }
 
-        return { standard, executable };
+        const executable = config.get<string>('executable');
+        if (executable === undefined) {
+            throw new Error('The extension has an invalid `executable` configuration.');
+        }
+
+        return { standard, autoExecutable, executable };
     }
 
     /**
-     * Infers the working directory of a document and returns it.
+     * Fetches the workspace folder of a document or the folder immediately enclosing the file.
      *
      * @param {TextDocument} document The document to check.
      */
-    private inferWorkingDirectory(document: TextDocument): string {
+    private getWorkspaceFolder(document: TextDocument): Uri {
         // When the file is in a workspace we should assume that is the working directory.
         const folder = this.workspace.getWorkspaceFolder(document.uri);
         if (folder) {
-            return folder.uri.fsPath;
+            return folder.uri;
         }
 
         // Our next best option is the root path.
         if (this.workspace.workspaceFolders && this.workspace.workspaceFolders.length > 0) {
-            return this.workspace.workspaceFolders[0].uri.fsPath;
+            return this.workspace.workspaceFolders[0].uri;
         }
 
-        // When we can't infer a path just use the path of the document.
-        return document.uri.fsPath;
+        // When we can't infer a path just use the directory of the document.
+        return Uri.joinPath(document.uri, '..');
     }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -128,7 +128,7 @@ export class Configuration {
         if (findExecutable) {
             // Start in the document's directory.
             let dir: Uri = Uri.joinPath(document.uri, '..');
-            while (dir) {
+            while (dir.path !== '.') {
                 const phpcsPath = Uri.joinPath(dir, 'vendor/bin/phpcs');
                 try {
                     await this.workspace.fs.stat(phpcsPath);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -103,8 +103,15 @@ export class Configuration {
 
     /**
      * Clears the cached configuration.
+     *
+     * @param {TextDocument} [document] The document to limit clearing to.
      */
-    public clearCache(): void {
+    public clearCache(document?: TextDocument): void {
+        if (document) {
+            this.cache.delete(document.uri);
+            return;
+        }
+
         this.cache.clear();
     }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -63,10 +63,10 @@ export class Configuration {
      *
      * @param {TextDocument} document The document we want to fetch the config for.
      */
-    public get(document: TextDocument): DocumentConfiguration {
+    public get(document: TextDocument): Promise<DocumentConfiguration> {
         let config = this.cache.get(document.uri);
         if (config) {
-            return config;
+            return Promise.resolve(config);
         }
 
         // Read the configuration and cache it to avoid doing so again.
@@ -78,7 +78,7 @@ export class Configuration {
         };
         this.cache.set(document.uri, config);
 
-        return config;
+        return Promise.resolve(config);
     }
 
     /**

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -70,7 +70,7 @@ describe('DiagnosticUpdater', () => {
                 return Promise.resolve(mockWorker);
             }
         )
-        mocked(mockConfiguration).get.mockReturnValue(
+        mocked(mockConfiguration).get.mockResolvedValue(
             {
                 workingDirectory: 'test-dir',
                 executable: 'phpcs-test',

--- a/src/services/code-action-edit-resolver.ts
+++ b/src/services/code-action-edit-resolver.ts
@@ -40,8 +40,8 @@ export class CodeActionEditResolver extends WorkerService {
         ].join(':');
 
         return this.workerPool.waitForAvailable(workerKey, cancellationToken)
-            .then((worker) => {
-                const config = this.configuration.get(document);
+            .then(async (worker) => {
+                const config = await this.configuration.get(document);
 
                 // Use the worker to make a request for a code action report.
                 const request: Request<ReportType.CodeAction> = {

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -72,8 +72,8 @@ export class DiagnosticUpdater extends WorkerService {
         }
 
         this.workerPool.waitForAvailable('diagnostic:' + document.fileName, cancellationToken)
-            .then((worker) => {
-                const config = this.configuration.get(document);
+            .then(async (worker) => {
+                const config = await this.configuration.get(document);
 
                 // Use the worker to make a request for a diagnostic report.
                 const request: Request<ReportType.Diagnostic> = {

--- a/src/services/document-formatter.ts
+++ b/src/services/document-formatter.ts
@@ -31,8 +31,8 @@ export class DocumentFormatter extends WorkerService {
         ].join(':');
 
         return this.workerPool.waitForAvailable(workerKey, cancellationToken)
-            .then((worker) => {
-                const config = this.configuration.get(document);
+            .then(async (worker) => {
+                const config = await this.configuration.get(document);
 
                 const data: FormatRequest = {};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

This PR adds a new `phpCodeSniffer.autoExecutable` option. When enabled the option will cause the extension to traverse from the file's directory to the workspace folder or root folder. If it finds a `vendor/bin/phpcs` file along the way it will use it instead of what is defined in the `phpCodeSniffer.executable` option.

Closes #3.

### How to test the changes in this Pull Request:

1. Set the `phpCodeSniffer.executable` to something invalid like `sleep`
2. Enable the `phpCodeSniffer.executableAuto`
3. Open a file in a repository that has a `composer.json` and installed with a `phpcs` dependency
4. Verify that the extension still works
