### PR TITLE
Support Custom Vendor Directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Automatically attempt to find a `vendor/bin/phpcs` file when `phpCodeSniffer.autoExecutable` is enabled.
+- Automatically attempt to find a `bin/phpcs` file in a vendor directory when `phpCodeSniffer.autoExecutable` is enabled.
 
 ### Fixed
 - Range formatting.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "properties": {
         "phpCodeSniffer.autoExecutable": {
           "type": "boolean",
-          "markdownDescription": "Attempts to find `vendor/bin/phpcs` in the file's directory and parent directories before falling back to `#phpCodeSniffer.executable#`.",
+          "markdownDescription": "Attempts to find `bin/phpcs` in the file directory and parent directories' vendor directory before falling back to `#phpCodeSniffer.executable#`.",
           "default": false,
           "scope": "resource"
         },

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -126,6 +126,7 @@ const workspace = {
     getWorkspaceFolder: jest.fn(),
     getConfiguration: jest.fn(),
     fs: {
+        readFile: jest.fn(),
         stat: jest.fn()
     }
 };

--- a/src/listeners/workspace-listener.ts
+++ b/src/listeners/workspace-listener.ts
@@ -118,7 +118,7 @@ export class WorkspaceListener implements Disposable {
         // We're going to be watching for filesystem events on PHPCS executables.
         // This will allow us to take action when an executable we're using is no
         // longer available as well as when a new executable becomes available.
-        const watcher = workspace.createFileSystemWatcher('**/vendor/bin/phpcs', false, true, false);
+        const watcher = workspace.createFileSystemWatcher('**/bin/phpcs', false, true, false);
         this.subscriptions.push(watcher);
         watcher.onDidCreate((e) => this.onExecutableChange(workspace, e));
         watcher.onDidDelete((e) => this.onExecutableChange(workspace, e));
@@ -191,7 +191,7 @@ export class WorkspaceListener implements Disposable {
     }
 
     /**
-     * A callback for `vendor/bin/phpcs` executables being created or deleted.
+     * A callback for `bin/phpcs` executables being created or deleted.
      *
      * @param {workspace} workspace The workspace the executable is part of.
      * @param {Uri} executable The Uri for the executable that has changed.


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

As a follow-up to #8 this PR extends the search for PHPCS executables to the `vendor-dir` config key of the project's `composer.json` file.

### How to test the changes in this Pull Request:

1. Create a test project with a custom `vendor-dir`
2. Verify that the extension uses the custom directory's executable
