### PR TITLE
Better Error Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Automatically attempt to find a `bin/phpcs` file in a vendor directory when `phpCodeSniffer.autoExecutable` is enabled.
+- Display PHPCS errors to the user.
+- Check document version before unnecessarily rebuilding diagnostics.
 
 ### Fixed
 - Range formatting.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { FormatDocumentProvider } from './providers/format-document-provider';
 import { CodeActionEditResolver } from './services/code-action-edit-resolver';
 import { DiagnosticUpdater } from './services/diagnostic-updater';
 import { DocumentFormatter } from './services/document-formatter';
+import { Logger } from './logger';
 
 export function activate(context: ExtensionContext): void {
     // We will store all of the diagnostics and code actions
@@ -18,16 +19,18 @@ export function activate(context: ExtensionContext): void {
     const codeActionCollection = new CodeActionCollection();
 
     // Create all of our dependencies.
+    const logger = new Logger(window);
     const configuration = new Configuration(workspace);
     const workerPool = new WorkerPool(10);
     const diagnosticUpdater = new DiagnosticUpdater(
+        logger,
         configuration,
         workerPool,
         diagnosticCollection,
         codeActionCollection
     );
-    const codeActionEditResolver = new CodeActionEditResolver(configuration, workerPool);
-    const documentFormatter = new DocumentFormatter(configuration, workerPool);
+    const codeActionEditResolver = new CodeActionEditResolver(logger, configuration, workerPool);
+    const documentFormatter = new DocumentFormatter(logger, configuration, workerPool);
     const commandProvider = new CommandProvider();
     const workspaceListener = new WorkspaceListener(
         configuration,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,63 @@
+import { Disposable, OutputChannel, window as vsCodeWindow } from 'vscode';
+import { PHPCSError } from './phpcs-report/worker';
+
+/**
+ * A logger for presenting errors to the user.
+ */
+export class Logger implements Disposable {
+    /**
+     * The window for logging errors.
+     */
+    private readonly window: typeof vsCodeWindow;
+
+    /**
+     * The output channel to log into.
+     */
+    private readonly outputChannel: OutputChannel;
+
+    /**
+     * Constructor.
+     *
+     * @param {window} window The window to log errors using.
+     */
+    public constructor(window: typeof vsCodeWindow) {
+        this.window = window;
+        this.outputChannel = this.window.createOutputChannel('PHP_CodeSniffer');
+    }
+
+    /**
+     * Disposes of a logger's resources.
+     */
+    public dispose(): void {
+        this.outputChannel.dispose();
+    }
+
+    /**
+     * Given an error this will take appropriate action to log it.
+     *
+     * @param {Error} error The error to log.
+     */
+    public error(error: Error): void {
+        // Users should be informed of PHPCS errors.
+        if (error instanceof PHPCSError) {
+            this.window.showErrorMessage(error.message);
+            this.outputChannel.show(true);
+            this.writeMessage(error.errorOutput || error.output);
+            return;
+        }
+
+        this.writeMessage(error.message);
+    }
+
+    /**
+     * Writes a message to the output channel.
+     *
+     * @param {string} message The message to write.
+     */
+    private writeMessage(message: string): void {
+        const now = new Date();
+        const timestamp = now.getFullYear() + '-' + now.getMonth() + '-' + now.getDay() + ' ' + now.getHours() + ':' + now.getMinutes() + now.getSeconds();
+        this.outputChannel.append('[' + timestamp + ']: ');
+        this.outputChannel.appendLine(message.trim());
+    }
+}

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -14,6 +14,34 @@ import { ReportType, Response } from './response';
 type ActiveChangedCallback = (worker: Worker) => void;
 
 /**
+ * A custom error type for those that come from PHPCS.
+ */
+export class PHPCSError extends Error {
+    /**
+     * The output from the command.
+     */
+    public readonly output: string;
+
+    /**
+     * The error output from the command.
+     */
+    public readonly errorOutput: string;
+
+    /**
+     * Constructor.
+     *
+     * @param {string} output The output from the command.
+     * @param {string} errorOutput The error output from the command.
+     */
+    public constructor(output: string, errorOutput: string) {
+        super('The PHPCS worker encountered an error.');
+
+        this.output = output;
+        this.errorOutput = errorOutput;
+    }
+}
+
+/**
  * A worker for getting reports out of PHPCS and returning them to the consumer.
  */
 export class Worker {
@@ -196,8 +224,7 @@ export class Worker {
             }
 
             if (code !== 0) {
-                console.error(pendingReport, pendingError);
-                resolve(Response.fromRaw(request.type, ''));
+                reject(new PHPCSError(pendingReport, pendingError));
                 return;
             }
 

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticCollection, workspace, Range, DiagnosticSeverity, CodeActionKind } from 'vscode';
+import { Diagnostic, DiagnosticCollection, workspace, window, Range, DiagnosticSeverity, CodeActionKind } from 'vscode';
 import { CodeAction, CodeActionCollection } from '../../code-action';
 import { Configuration, StandardType } from '../../configuration';
 import { WorkerPool } from '../../phpcs-report/worker-pool';
@@ -7,6 +7,7 @@ import { MockDiagnosticCollection, MockTextDocument } from '../../__mocks__/vsco
 import { mocked } from 'ts-jest/utils';
 import { Worker } from '../../phpcs-report/worker';
 import { ReportType, Response } from '../../phpcs-report/response';
+import { Logger } from '../../logger';
 
 jest.mock('../../phpcs-report/report-files', () => {
     return {
@@ -22,6 +23,7 @@ jest.mock('../../phpcs-report/report-files', () => {
         }
     };
 });
+jest.mock('../../logger');
 jest.mock('../../configuration');
 jest.mock('../../phpcs-report/worker');
 jest.mock('../../phpcs-report/worker-pool');
@@ -39,6 +41,7 @@ jest.mock('../../code-action', () => {
 });
 
 describe('DiagnosticUpdater', () => {
+    let mockLogger: Logger;
     let mockConfiguration: Configuration;
     let mockWorkerPool: WorkerPool;
     let mockDiagnosticCollection: DiagnosticCollection;
@@ -46,12 +49,14 @@ describe('DiagnosticUpdater', () => {
     let diagnosticUpdater: DiagnosticUpdater;
 
     beforeEach(() => {
+        mockLogger = new Logger(window);
         mockConfiguration = new Configuration(workspace);
         mockWorkerPool = new WorkerPool(1);
         mockDiagnosticCollection = new MockDiagnosticCollection();
         mockCodeActionCollection = new CodeActionCollection();
 
         diagnosticUpdater = new DiagnosticUpdater(
+            mockLogger,
             mockConfiguration,
             mockWorkerPool,
             mockDiagnosticCollection,

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -1,4 +1,5 @@
 import { CancellationToken, CancellationTokenSource, Disposable, TextDocument, Uri } from 'vscode';
+import { Logger } from '../logger';
 import { Configuration } from '../configuration';
 import { WorkerPool } from '../phpcs-report/worker-pool';
 
@@ -6,6 +7,11 @@ import { WorkerPool } from '../phpcs-report/worker-pool';
  * A base class for all of the updates that interact with PHPCS.
  */
 export abstract class WorkerService implements Disposable {
+    /**
+     * The logger to use.
+     */
+    protected readonly logger: Logger;
+
     /**
      * The configuration object.
      */
@@ -24,10 +30,12 @@ export abstract class WorkerService implements Disposable {
     /**
      * Constructor.
      *
+     * @param {Logger} logger The logger to use.
      * @param {Configuration} configuration The configuration object to use.
      * @param {WorkerPool} workerPool The worker pool to use.
      */
-    public constructor(configuration: Configuration, workerPool: WorkerPool) {
+    public constructor(logger: Logger, configuration: Configuration, workerPool: WorkerPool) {
+        this.logger = logger;
         this.configuration = configuration;
         this.workerPool = workerPool;
         this.cancellationTokenSourceMap = new Map();


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Rather than silently logging errors to the console we should notify the user when PHPCS fails and create a channel for them to respond to the error feedback. This PR adds a new output channel for the extension as well as a notification that informs them of the error.

### How to test the changes in this Pull Request:

1. Use an invalid `phpCodeSniffer.executable` option like `sleep` that will fail
2. Ensure that the error is rendered to the output channel.
