### PR TITLE
Made onDidChangeTextDocument Handling Better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Only trigger diagnostic updates when changes have occurred.
+- Dispose of `Logger` correctly.
 
 ## [0.4.0] - 2021-02-21
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ export function activate(context: ExtensionContext): void {
     );
 
     // Make sure all of our dependencies will be cleaned up.
+    context.subscriptions.push(logger);
     context.subscriptions.push(diagnosticUpdater);
     context.subscriptions.push(codeActionEditResolver);
     context.subscriptions.push(documentFormatter);


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

We're currently listening to `workspace.onDidChangeTextDocument` and `workspace.onDidSaveTextDocument` in order to generate diagnostic updates. This has proven slow because `onDidChangeTextDocument` is triggered _very_ frequently and `onDidSaveTextDocument` is triggered by autosave. Based on the observation that the diagnostics should only change when the content does, this PR alters the behavior to do just that.

### How to test the changes in this Pull Request:

1. Verify that the extension updates diagnostics correctly
