### PR TITLE
Refactored Executable Discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .DS_Store
 
 # Project Files
-.vscode/
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
 
 # Build Artifacts
 out/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "Launch Extension",
+            "type": "pwa-extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle Uri schemes other than `'file'`.
 
 ## [0.4.1] - 2021-02-22
 ### Fixed

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -113,7 +113,7 @@ const TextEdit = jest.fn().mockImplementation((range, newContent) => {
 class FileSystemError extends Error {
     public readonly code: string;
 
-    public constructor(messageOrUri: string | typeof Uri) {
+    public constructor(messageOrUri: string|typeof Uri) {
         super(messageOrUri.toString());
 
         this.code = '';

--- a/src/listeners/workspace-listener.ts
+++ b/src/listeners/workspace-listener.ts
@@ -180,8 +180,6 @@ export class WorkspaceListener implements Disposable {
         }
         this.documents.set(document.uri, document);
 
-        console.log('Update');
-
         // Apply a debounce so that we don't perform the update too quickly.
         let debounce = this.updateDebounceMap.get(document.uri);
         if (debounce) {

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -96,7 +96,7 @@ export class Worker {
 
             // When a consumer passes a cancellation token we will use that to signal
             // that the running request should be terminated and the worker freed.
-            let cancellationHandler: Disposable | null = null;
+            let cancellationHandler: Disposable|null = null;
             if (cancellationToken) {
                 // Keep track of the handler so that we can remove it when cancellation is no longer possible.
                 cancellationHandler = cancellationToken.onCancellationRequested(() => this.onCancellation(cancellationToken));


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Currently the `phpCodeSniffer.autoExecutable` setting causes the `Configuration` class to perform a directory traversal looking for a viable `phpcs` executable. While this works great for `'file'` Uri schemes it doesn't work so well for any other. This PR makes the decision to traverse more explicitly tied to the scheme. I've also added handling for `'untitled'` documents which fixes https://github.com/ObliviousHarmony/vscode-php-codesniffer/issues/13.

Closes https://github.com/ObliviousHarmony/vscode-php-codesniffer/issues/14.

### How to test the changes in this Pull Request:

1. Ensure extension works correctly.
2. Ensure untitled documents use the workspace folder's executable when available.
