### PR TITLE
Pass Path To PHPCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2021-03-01
 ### Fixed
+- Pass file path to `phpcs` for use in sniffs.
 - Handle Uri schemes other than `'file'`.
 
 ## [0.4.1] - 2021-02-22

--- a/src/phpcs-report/__tests__/worker-integration.test.ts
+++ b/src/phpcs-report/__tests__/worker-integration.test.ts
@@ -46,6 +46,7 @@ describe('Worker/WorkerPool Integration', () => {
             .then((worker) => {
                 const request: Request<ReportType.Diagnostic> = {
                     type: ReportType.Diagnostic,
+                    documentPath: 'Test.php',
                     documentContent: '<?php class Test {}',
                     options: {
                         workingDirectory: __dirname,
@@ -74,6 +75,7 @@ describe('Worker/WorkerPool Integration', () => {
             .then((worker) => {
                 const request: Request<ReportType.Diagnostic> = {
                     type: ReportType.Diagnostic,
+                    documentPath: 'Test.php',
                     documentContent: '<?php class Test {}',
                     options: {
                         workingDirectory: __dirname,

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -44,6 +44,7 @@ describe('Worker', () => {
 
         const request: Request<ReportType.Diagnostic> = {
             type: ReportType.Diagnostic,
+            documentPath: 'Test.php',
             documentContent: '',
             options: {
                 workingDirectory: __dirname,
@@ -65,6 +66,7 @@ describe('Worker', () => {
 
         const request: Request<ReportType.Diagnostic> = {
             type: ReportType.Diagnostic,
+            documentPath: 'Test.php',
             documentContent: '<?php class Test {}',
             options: {
                 workingDirectory: __dirname,
@@ -88,6 +90,7 @@ describe('Worker', () => {
 
         const request: Request<ReportType.CodeAction> = {
             type: ReportType.CodeAction,
+            documentPath: 'Test.php',
             documentContent: '<?php class Test {}',
             options: {
                 workingDirectory: __dirname,
@@ -127,6 +130,7 @@ describe('Worker', () => {
 
         const request: Request<ReportType.Format> = {
             type: ReportType.Format,
+            documentPath: 'Test.php',
             documentContent: '<?php class Test {}',
             options: {
                 workingDirectory: __dirname,
@@ -148,6 +152,7 @@ describe('Worker', () => {
 
         const request: Request<ReportType.Diagnostic> = {
             type: ReportType.Diagnostic,
+            documentPath: 'Test.php',
             documentContent: '<?php class Test {}',
             options: {
                 workingDirectory: __dirname,
@@ -173,6 +178,7 @@ describe('Worker', () => {
 
         const request: Request<ReportType.Diagnostic> = {
             type: ReportType.Diagnostic,
+            documentPath: 'Test.php',
             documentContent: '<?php class Test {}',
             options: {
                 workingDirectory: __dirname,

--- a/src/phpcs-report/request.ts
+++ b/src/phpcs-report/request.ts
@@ -49,6 +49,11 @@ export interface Request<T extends ReportType> {
     type: T;
 
     /**
+     * The filesystem path for the document that the report is being generated for.
+     */
+    documentPath: string;
+
+    /**
      * The content for the document that the report is being generated for.
      */
     documentContent: string;

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -234,6 +234,8 @@ export class Worker {
 
         // Send the document to be handled.
         if (phpcsProcess.stdin.writable) {
+            // Write the input file path before the content so PHPCS can utilize it.
+            phpcsProcess.stdin.write('phpcs_input_file: ' + request.documentPath + '\n');
             phpcsProcess.stdin.end(request.documentContent);
         }
 

--- a/src/services/code-action-edit-resolver.ts
+++ b/src/services/code-action-edit-resolver.ts
@@ -46,6 +46,7 @@ export class CodeActionEditResolver extends WorkerService {
                 // Use the worker to make a request for a code action report.
                 const request: Request<ReportType.CodeAction> = {
                     type: ReportType.CodeAction,
+                    documentPath: document.uri.fsPath,
                     documentContent: document.getText(),
                     options: {
                         workingDirectory: config.workingDirectory,

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -82,6 +82,7 @@ export class DiagnosticUpdater extends WorkerService {
                 // Use the worker to make a request for a diagnostic report.
                 const request: Request<ReportType.Diagnostic> = {
                     type: ReportType.Diagnostic,
+                    documentPath: document.uri.fsPath,
                     documentContent: document.getText(),
                     options: {
                         workingDirectory: config.workingDirectory,

--- a/src/services/document-formatter.ts
+++ b/src/services/document-formatter.ts
@@ -44,6 +44,7 @@ export class DocumentFormatter extends WorkerService {
                 // Use the worker to make a request for a format report.
                 const request: Request<ReportType.Format> = {
                     type: ReportType.Format,
+                    documentPath: document.uri.fsPath,
                     documentContent: document.getText(),
                     options: {
                         workingDirectory: config.workingDirectory,


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Since some sniffs check the file path it makes sense for us to send the path using PHPCS' `phpcs_input_file: [path]` feature. When prepended to the content this line is used by PHPCS to set the filename of STDIN files.

Closes https://github.com/ObliviousHarmony/vscode-php-codesniffer/issues/16.

### How to test the changes in this Pull Request:

1. Try out an invalid filename sniff and make sure it works now.
