### PR TITLE
Fixed "Ignore * for this line" Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<<<<<<< HEAD
 ### Added
 - Ignore diagnostics for files using `phpCodeSniffer.ignorePatterns` option.
+=======
+### Fixed
+- "Ignore * for this line" action should be present for all diagnostics.
+>>>>>>> f8802f9 (Fixed "Ignore * for this line" Actions)
 
 ## [1.0.0] - 2021-03-01
 ### Fixed

--- a/src/providers/code-action-provider.ts
+++ b/src/providers/code-action-provider.ts
@@ -1,15 +1,12 @@
 import {
     CancellationToken,
     CodeActionContext,
-    CodeActionKind,
     CodeActionProvider as BaseProvider,
-    Diagnostic,
     ProviderResult,
     Range,
     TextDocument,
 } from 'vscode';
 import { CodeAction, CodeActionCollection } from '../types';
-import { IgnoreLineCommand } from '../commands/ignore-line-command';
 import { CodeActionEditResolver } from '../services/code-action-edit-resolver';
 
 /**
@@ -71,7 +68,6 @@ export class CodeActionProvider implements BaseProvider<CodeAction> {
             action.document = document;
 
             filteredActions.push(action);
-            filteredActions.push(...this.getSupplementalActions(document, diagnostic));
         }
 
         return filteredActions;
@@ -92,30 +88,5 @@ export class CodeActionProvider implements BaseProvider<CodeAction> {
         }
 
         return this.codeActionEditResolver.resolve(codeAction, cancellationToken);
-    }
-
-    /**
-     * Fetches all of the supplemental actions that this one has created.
-     *
-     * @param {TextDocument} document The document for the actions.
-     * @param {Diagnostic} diagnostic The diagnostic we're building actions for.
-     */
-    private getSupplementalActions(document: TextDocument, diagnostic: Diagnostic): CodeAction[] {
-        const supplementalActions: CodeAction[] = [];
-
-        const action = new CodeAction('Ignore ' + diagnostic.code + ' for this line', CodeActionKind.QuickFix);
-        action.diagnostics = [ diagnostic ];
-        action.command = {
-            title: 'Ignore PHP_CodeSniffer',
-            command: IgnoreLineCommand.COMMAND,
-            arguments: [
-                document,
-                diagnostic.code,
-                diagnostic.range.start.line
-            ]
-        };
-        supplementalActions.push(action);
-
-        return supplementalActions;
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

As a consequence of adding the supplemental code actions when providing actions, any Diagnostic without a fix action also had no ignore action. This moves the generation of these actions into the DiagnosticUpdater so they can be generated for all diagnostics.

Fixes #18

### How to test the changes in this Pull Request:

1. Prepare a file with an unfixable error
2. The "Ignore * for this line" action should now be present
