### PR TITLE
Added Linting Status Indicator

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { CodeActionEditResolver } from './services/code-action-edit-resolver';
 import { DiagnosticUpdater } from './services/diagnostic-updater';
 import { DocumentFormatter } from './services/document-formatter';
 import { Logger } from './services/logger';
+import { LinterStatus } from './services/linter-status';
 
 export function activate(context: ExtensionContext): void {
 	// We will store all of the diagnostics and code actions
@@ -27,12 +28,14 @@ export function activate(context: ExtensionContext): void {
 
 	// Create all of our dependencies.
 	const logger = new Logger(window);
+	const linterStatus = new LinterStatus(window);
 	const configuration = new Configuration(workspace);
 	const workerPool = new WorkerPool(10);
 	const diagnosticUpdater = new DiagnosticUpdater(
 		logger,
 		configuration,
 		workerPool,
+		linterStatus,
 		diagnosticCollection,
 		codeActionCollection
 	);
@@ -56,6 +59,7 @@ export function activate(context: ExtensionContext): void {
 
 	// Make sure all of our dependencies will be cleaned up.
 	context.subscriptions.push(logger);
+	context.subscriptions.push(linterStatus);
 	context.subscriptions.push(diagnosticUpdater);
 	context.subscriptions.push(codeActionEditResolver);
 	context.subscriptions.push(documentFormatter);

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -19,6 +19,7 @@ import { mocked } from 'ts-jest/utils';
 import { Worker } from '../../phpcs-report/worker';
 import { ReportType, Response } from '../../phpcs-report/response';
 import { Logger } from '../../services/logger';
+import { LinterStatus } from '../linter-status';
 
 jest.mock('../../phpcs-report/report-files', () => {
 	return {
@@ -34,7 +35,8 @@ jest.mock('../../phpcs-report/report-files', () => {
 		},
 	};
 });
-jest.mock('..//logger');
+jest.mock('../logger');
+jest.mock('../linter-status');
 jest.mock('../configuration');
 jest.mock('../../phpcs-report/worker');
 jest.mock('../../phpcs-report/worker-pool');
@@ -56,6 +58,7 @@ describe('DiagnosticUpdater', () => {
 	let mockLogger: Logger;
 	let mockConfiguration: Configuration;
 	let mockWorkerPool: WorkerPool;
+	let mockLinterStatus: LinterStatus;
 	let mockDiagnosticCollection: DiagnosticCollection;
 	let mockCodeActionCollection: CodeActionCollection;
 	let diagnosticUpdater: DiagnosticUpdater;
@@ -64,6 +67,7 @@ describe('DiagnosticUpdater', () => {
 		mockLogger = new Logger(window);
 		mockConfiguration = new Configuration(workspace);
 		mockWorkerPool = new WorkerPool(1);
+		mockLinterStatus = new LinterStatus(window);
 		mockDiagnosticCollection = new MockDiagnosticCollection();
 		mockCodeActionCollection = new CodeActionCollection();
 
@@ -71,6 +75,7 @@ describe('DiagnosticUpdater', () => {
 			mockLogger,
 			mockConfiguration,
 			mockWorkerPool,
+			mockLinterStatus,
 			mockDiagnosticCollection,
 			mockCodeActionCollection
 		);

--- a/src/services/linter-status.ts
+++ b/src/services/linter-status.ts
@@ -1,0 +1,81 @@
+import {
+	Disposable,
+	StatusBarAlignment,
+	StatusBarItem,
+	Uri,
+	window as vsCodeWindow,
+} from 'vscode';
+
+/**
+ * A class for managing the linter's status.
+ */
+export class LinterStatus implements Disposable {
+	/**
+	 * The status bar item we're using to display the status of the linter.
+	 */
+	private readonly statusBar: StatusBarItem;
+
+	/**
+	 * The documents that are actively being linted.
+	 */
+	private readonly activeDocuments: Set<Uri>;
+
+	/**
+	 * Constructor.
+	 */
+	public constructor(window: typeof vsCodeWindow) {
+		this.statusBar = window.createStatusBarItem(StatusBarAlignment.Left);
+		this.activeDocuments = new Set();
+	}
+
+	/**
+	 * Cleans up the class' resources.
+	 */
+	public dispose(): void {
+		this.statusBar.dispose();
+	}
+
+	/**
+	 * Records that a document has begun being linted.
+	 *
+	 * @param {Uri} documentUri The Uri for a document being linted.
+	 */
+	public start(documentUri: Uri): void {
+		this.activeDocuments.add(documentUri);
+		this.updateBar();
+	}
+
+	/**
+	 * Records that a document has stopped being linted.
+	 *
+	 * @param {Uri} documentUri The Uri for a document being linted.
+	 */
+	public stop(documentUri: Uri): void {
+		this.activeDocuments.delete(documentUri);
+		this.updateBar();
+	}
+
+	/**
+	 * Updates the status bar content according to the linting that is taking place.
+	 */
+	private updateBar(): void {
+		// Hide the status bar when there's no documents linting.
+		if (this.activeDocuments.size === 0) {
+			this.statusBar.hide();
+			return;
+		}
+
+		// Make sure the status bar is visible.
+		this.statusBar.show();
+
+		// Update the status to indicate the number of documents we're procesing.
+		let status = '$(sync~spin) PHP_CodeSniffer Processing ';
+		if (this.activeDocuments.size > 1) {
+			status += this.activeDocuments.size + ' documents...';
+		} else {
+			status += '1 document...';
+		}
+
+		this.statusBar.text = status;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Rather than simply listing silently, this PR introduces a status bar indicator when the PHPCS linter is executing.

Closes #24.

### How to test the changes in this Pull Request:

1. Start linting a large document.
2. Notice the indicator in the bottom-left.
