### PR TITLE
Added Cancel Processing Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Command `phpCodeSniffer.cancelProcessing` to cancel all active processing.
 
 ## [1.3.0] - 2021-05-24
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -89,7 +89,13 @@
           "scope": "window"
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "phpCodeSniffer.cancelProcessing",
+        "title": "PHP_CodeSniffer: Cancel Processing"
+      }
+    ]
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/src/commands/cancel-processing-command.ts
+++ b/src/commands/cancel-processing-command.ts
@@ -1,0 +1,34 @@
+import { WorkerService } from '../services/worker-service';
+
+/**
+ * A class for handling the command that cancels all active document processing.
+ */
+export class CancelProcessingCommand {
+	/**
+	 * The identifier for the command.
+	 */
+	public static readonly COMMAND = 'phpCodeSniffer.cancelProcessing';
+
+	/**
+	 * All of the worker services that we should cancel execution for.
+	 */
+	private readonly cancellableServices: WorkerService[];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param {workspace} workspace The VS Code workspace.
+	 */
+	public constructor(cancellableServices: WorkerService[]) {
+		this.cancellableServices = cancellableServices;
+	}
+
+	/**
+	 * Handles the command.
+	 */
+	public handle(): void {
+		for (const service of this.cancellableServices) {
+			service.cancelAll();
+		}
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,11 @@ export function activate(context: ExtensionContext): void {
 		configuration,
 		workerPool
 	);
-	const commandProvider = new CommandProvider();
+	const commandProvider = new CommandProvider(
+		diagnosticUpdater,
+		codeActionEditResolver,
+		documentFormatter
+	);
 	const workspaceListener = new WorkspaceListener(
 		configuration,
 		diagnosticUpdater,

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -78,6 +78,17 @@ export abstract class WorkerService implements Disposable {
 	}
 
 	/**
+	 * Cancels in-progress updates for all documents.
+	 */
+	public cancelAll(): void {
+		for (const kvp of this.cancellationTokenSourceMap) {
+			kvp[1].cancel();
+			kvp[1].dispose();
+		}
+		this.cancellationTokenSourceMap.clear();
+	}
+
+	/**
 	 * A handler to be called when a document is closed to clean up after it.
 	 *
 	 * @param {TextDocument} document The document that was closed.


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

While I couldn't replicate the stalling behaviour in #31, it makes sense for there to be a way to stop the extension's workers without having to restart VS Code. This pull request adds a new command to the palette that cancels every worker service, allowing the user to start fresh with linting.

Closes #31.

### How to test the changes in this Pull Request:

1. Open a file that will take some time to process and confirm that the status bar indicates activity.
2. Execute the `PHP_CodeSniffer: Cancel Processing` command and the status bar should clear.
