### PR TITLE
Add option to configure when diagnostics are updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Linter's execution action can be set by the `phpCodeSniffer.lintAction` option.
 
 ## [1.3.0] - 2021-05-24
 ### Fixed
@@ -22,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2021-03-04
 ### Added
-- Ignore diagnostics for files using `phpCodeSniffer.ignorePatterns` option.
+- Ignore diagnostics for files using the `phpCodeSniffer.ignorePatterns` option.
 
 ### Fixed
 - "Ignore * for this line" action should be present for all diagnostics.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,20 @@
           },
           "scope": "window"
         },
+        "phpCodeSniffer.lintAction": {
+          "type": "string",
+          "description": "The editor action that will cause the linter to run.",
+          "default": "Change",
+          "enum": [
+            "Change",
+            "Save"
+          ],
+          "enumDescriptions": [
+            "Lints whenever a document is changed.",
+            "Lints when a document is saved."
+          ],
+          "scope": "resource"
+        },
         "phpCodeSniffer.standard": {
           "type": "string",
           "description": "The coding standard that should be used by PHPCS.",

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../../__mocks__/vscode';
 import { TextEncoder } from 'util';
 import { mocked } from 'ts-jest/utils';
-import { Configuration, StandardType } from '../configuration';
+import { Configuration, LintAction, StandardType } from '../configuration';
 
 describe('Configuration', () => {
 	let mockDocument: TextDocument;
@@ -71,6 +71,8 @@ describe('Configuration', () => {
 					return 'test.exec';
 				case 'ignorePatterns':
 					return ['test'];
+				case 'lintAction':
+					return LintAction.Change;
 				case 'standard':
 					return StandardType.Disabled;
 			}
@@ -153,6 +155,8 @@ describe('Configuration', () => {
 					return 'test.exec';
 				case 'ignorePatterns':
 					return ['test'];
+				case 'lintAction':
+					return LintAction.Change;
 				case 'standard':
 					return StandardType.Disabled;
 			}
@@ -237,6 +241,8 @@ describe('Configuration', () => {
 					return 'test.exec';
 				case 'ignorePatterns':
 					return ['test'];
+				case 'lintAction':
+					return LintAction.Change;
 				case 'standard':
 					return StandardType.Disabled;
 			}

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -3,8 +3,13 @@ import {
 	workspace,
 	Uri as vsCodeUri,
 	FileSystemError,
+	CancellationError,
 } from 'vscode';
-import { MockTextDocument, Uri } from '../../__mocks__/vscode';
+import {
+	MockCancellationToken,
+	MockTextDocument,
+	Uri,
+} from '../../__mocks__/vscode';
 import { TextEncoder } from 'util';
 import { mocked } from 'ts-jest/utils';
 import { Configuration, StandardType } from '../configuration';
@@ -175,5 +180,77 @@ describe('Configuration', () => {
 
 		expect(workspace.getConfiguration).toHaveBeenCalledTimes(1);
 		expect(cached).toMatchObject(result);
+	});
+
+	it('should support cancellation', () => {
+		const cancellationToken = new MockCancellationToken();
+
+		const mockConfiguration = { get: jest.fn() };
+		mocked(workspace).getConfiguration.mockReturnValue(
+			mockConfiguration as never
+		);
+
+		const workspaceUri = new Uri();
+		workspaceUri.path = 'test';
+		workspaceUri.fsPath = 'test';
+		mocked(workspace).getWorkspaceFolder.mockReturnValue({
+			uri: workspaceUri,
+		} as never);
+
+		// We will traverse from the file directory up.
+		mocked(workspace.fs.readFile).mockImplementation((uri) => {
+			switch (uri.path) {
+				case 'test/file/composer.json':
+					return Promise.reject(new FileSystemError(uri));
+				case 'test/composer.json': {
+					const json = JSON.stringify({
+						config: {
+							'vendor-dir': 'newvendor',
+						},
+					});
+					const encoder = new TextEncoder();
+					return Promise.resolve(encoder.encode(json));
+				}
+			}
+
+			throw new Error('Invalid path: ' + uri.path);
+		});
+
+		mocked(workspace.fs.stat).mockImplementation((uri) => {
+			switch (uri.path) {
+				case 'test/newvendor/bin/phpcs': {
+					const ret = new Uri();
+					ret.path = 'test';
+					ret.fsPath = 'test';
+					return Promise.resolve(ret);
+				}
+			}
+
+			throw new Error('Invalid path: ' + uri.path);
+		});
+
+		mockConfiguration.get.mockImplementation((key) => {
+			switch (key) {
+				case 'autoExecutable':
+					return true;
+				case 'executable':
+					return 'test.exec';
+				case 'ignorePatterns':
+					return ['test'];
+				case 'standard':
+					return StandardType.Disabled;
+			}
+
+			fail(
+				'An unexpected configuration key of ' + key + ' was received.'
+			);
+		});
+
+		const promise = configuration.get(mockDocument, cancellationToken);
+
+		// Mock a cancellation so that resolution will reject.
+		cancellationToken.mockCancel();
+
+		return expect(promise).rejects.toMatchObject(new CancellationError());
 	});
 });

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -8,7 +8,11 @@ import {
 	CodeActionKind,
 } from 'vscode';
 import { CodeAction, CodeActionCollection } from '../../types';
-import { Configuration, StandardType } from '../../services/configuration';
+import {
+	Configuration,
+	LintAction,
+	StandardType,
+} from '../../services/configuration';
 import { WorkerPool } from '../../phpcs-report/worker-pool';
 import { DiagnosticUpdater } from '../diagnostic-updater';
 import {
@@ -16,7 +20,7 @@ import {
 	MockTextDocument,
 } from '../../__mocks__/vscode';
 import { mocked } from 'ts-jest/utils';
-import { Worker } from '../../phpcs-report/worker';
+import { PHPCSError, Worker } from '../../phpcs-report/worker';
 import { ReportType, Response } from '../../phpcs-report/response';
 import { Logger } from '../../services/logger';
 import { LinterStatus } from '../linter-status';
@@ -96,6 +100,7 @@ describe('DiagnosticUpdater', () => {
 			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',
 			ignorePatterns: [],
+			lintAction: LintAction.Change,
 			standard: StandardType.PSR12,
 		});
 		mocked(mockWorker).execute.mockImplementation((request) => {
@@ -124,17 +129,57 @@ describe('DiagnosticUpdater', () => {
 				},
 			};
 
-			// Wait for the updater to process the result before completing the test.
-			setTimeout(() => {
-				expect(mockDiagnosticCollection.set).toHaveBeenCalled();
-				expect(mockCodeActionCollection.set).toHaveBeenCalled();
-				done();
-			}, 5);
-
 			return Promise.resolve(response);
 		});
 
-		diagnosticUpdater.update(document);
+		// Wait for the updater to process the result before completing the test.
+		setTimeout(() => {
+			expect(mockDiagnosticCollection.set).toHaveBeenCalled();
+			expect(mockCodeActionCollection.set).toHaveBeenCalled();
+			done();
+		}, 5);
+
+		diagnosticUpdater.update(document, LintAction.Force);
+	});
+
+	it('should log PHPCS errors', (done) => {
+		const document = new MockTextDocument();
+		document.fileName = 'test-document';
+
+		const mockWorker = new Worker();
+		mocked(mockWorkerPool).waitForAvailable.mockImplementation(
+			(workerKey) => {
+				expect(workerKey).toBe('diagnostic:test-document');
+				return Promise.resolve(mockWorker);
+			}
+		);
+		mocked(mockConfiguration).get.mockResolvedValue({
+			workingDirectory: 'test-dir',
+			executable: 'phpcs-test',
+			ignorePatterns: [],
+			lintAction: LintAction.Change,
+			standard: StandardType.PSR12,
+		});
+		mocked(mockWorker).execute.mockImplementation((request) => {
+			expect(request).toMatchObject({
+				type: ReportType.Diagnostic,
+				options: {
+					workingDirectory: 'test-dir',
+					executable: 'phpcs-test',
+					standard: StandardType.PSR12,
+				},
+			});
+
+			throw new PHPCSError('Test Failure', 'Test Failure');
+		});
+
+		// Wait for the updater to process the result before completing the test.
+		setTimeout(() => {
+			expect(mockLogger.error).toHaveBeenCalled();
+			done();
+		}, 5);
+
+		diagnosticUpdater.update(document, LintAction.Force);
 	});
 
 	it('should respect ignore patterns', () => {
@@ -149,6 +194,21 @@ describe('DiagnosticUpdater', () => {
 			standard: StandardType.PSR12,
 		});
 
-		return diagnosticUpdater.update(document);
+		return diagnosticUpdater.update(document, LintAction.Force);
+	});
+
+	it('should not update on change when configured to save', () => {
+		const document = new MockTextDocument();
+		document.fileName = 'test-document';
+
+		mocked(mockConfiguration).get.mockResolvedValue({
+			workingDirectory: 'test-dir',
+			executable: 'phpcs-test',
+			ignorePatterns: [],
+			lintAction: LintAction.Save,
+			standard: StandardType.PSR12,
+		});
+
+		return diagnosticUpdater.update(document, LintAction.Change);
 	});
 });

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -137,36 +137,18 @@ describe('DiagnosticUpdater', () => {
 		diagnosticUpdater.update(document);
 	});
 
-	it('should respect ignore patterns', async (done) => {
+	it('should respect ignore patterns', () => {
 		const document = new MockTextDocument();
 		document.fileName = 'test-document';
 
-		const mockWorker = new Worker();
-		mocked(mockWorkerPool).waitForAvailable.mockImplementation(
-			(workerKey) => {
-				expect(workerKey).toBe('diagnostic:test-document');
-
-				// Wait for the updater to process the result before completing the test.
-				setTimeout(() => {
-					expect(
-						mockDiagnosticCollection.delete
-					).toHaveBeenCalledWith(document.uri);
-					expect(
-						mockCodeActionCollection.delete
-					).toHaveBeenCalledWith(document.uri);
-					done();
-				}, 5);
-
-				return Promise.resolve(mockWorker);
-			}
-		);
 		mocked(mockConfiguration).get.mockResolvedValue({
 			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',
 			ignorePatterns: [new RegExp('.*/file/.*')],
+			lintAction: LintAction.Change,
 			standard: StandardType.PSR12,
 		});
 
-		diagnosticUpdater.update(document);
+		return diagnosticUpdater.update(document);
 	});
 });

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -7,14 +7,19 @@ import {
 } from 'vscode';
 import { CodeAction, CodeActionCollection } from '../types';
 import { IgnoreLineCommand } from '../commands/ignore-line-command';
-import { Configuration } from './configuration';
+import { Configuration, LintAction } from './configuration';
 import { Logger } from './logger';
 import { Request } from '../phpcs-report/request';
-import { ReportType, Response } from '../phpcs-report/response';
+import { ReportType } from '../phpcs-report/response';
 import { PHPCSError } from '../phpcs-report/worker';
 import { WorkerPool } from '../phpcs-report/worker-pool';
 import { WorkerService } from './worker-service';
 import { LinterStatus } from './linter-status';
+
+/**
+ * A custom error type for identifying when an update was prevented.
+ */
+class UpdatePreventedError extends Error {}
 
 /**
  * A class for updating diagnostics and code actions.
@@ -84,8 +89,9 @@ export class DiagnosticUpdater extends WorkerService {
 	 * Updates a document's diagnostics.
 	 *
 	 * @param {TextDocument} document The document to update the diagnostics for.
+	 * @param {LintAction} lintAction The editor action that triggered this update.
 	 */
-	public update(document: TextDocument): void {
+	public update(document: TextDocument, lintAction: LintAction): void {
 		const cancellationToken = this.createCancellationToken(document);
 		if (!cancellationToken) {
 			return;
@@ -106,8 +112,26 @@ export class DiagnosticUpdater extends WorkerService {
 				// diagnostics for files that the user is not interested in receiving them for.
 				for (const pattern of configuration.ignorePatterns) {
 					if (pattern.test(document.uri.fsPath)) {
-						return Response.empty(ReportType.Diagnostic);
+						throw new UpdatePreventedError();
 					}
+				}
+
+				// Allow users to decide when the diagnostics are updated.
+				switch (lintAction) {
+					case LintAction.Change:
+						// Allow users to restrict updates to explicit save actions.
+						if (configuration.lintAction === LintAction.Save) {
+							throw new UpdatePreventedError();
+						}
+
+						break;
+
+					case LintAction.Save:
+						// When linting on change, we will always have the latest diagnostics, and don't need to update.
+						if (configuration.lintAction === LintAction.Change) {
+							throw new UpdatePreventedError();
+						}
+						break;
 				}
 
 				return this.workerPool
@@ -165,11 +189,16 @@ export class DiagnosticUpdater extends WorkerService {
 				);
 			})
 			.catch((e) => {
+				// Cancellation errors are acceptable as they mean we've just repeated the update before it completed.
+				if (e instanceof CancellationError) {
+					return;
+				}
+
 				// Let the status know we're not linting the document anymore.
 				this.linterStatus.stop(document.uri);
 
-				// Cancellation errors are acceptable as they mean we've just repeated the update before it completed.
-				if (e instanceof CancellationError) {
+				// Updates can be prevented in expected ways, so this error is acceptable.
+				if (e instanceof UpdatePreventedError) {
 					return;
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

This pull request adds a new `phpCodeSniffer.lintAction` configuration option that can be used to set when the linter is triggered. When set to "Save", diagnostics will not be updated until the user explicitly saves the document.

Closes #32.

### How to test the changes in this Pull Request:

1. Open a PHP document.
2. Confirm that the default of "Change" works by introducing and resolving PHPCS errors.
3. Change `phpCodeSniffer.lintAction` to "Save".
4. Confirm that diagnostics are only updated when the document is saved. Note that this would include autosave as well, so you may need to turn it off to see the difference.
5. Confirm that diagnostics are _also_ updated when the executable change is triggered, or configuration is changed for the file's workspace folder.
6. Confirm that code actions and document formatting continue to function as expected.
