### PR TITLE
Format Selection No Longer Limited To First Character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.6.0] - 2022-05-06
 ### Fixed
 - Document formatting with no changes clears diagnostics.
+- Document selection formatting only works on the first character of the diagnostic.
 
 ## [1.6.0] - 2022-05-06
 ### Fixed

--- a/assets/phpcs-integration/Extension/File.php
+++ b/assets/phpcs-integration/Extension/File.php
@@ -203,40 +203,31 @@ class File extends BaseFile
         return $this->getTextEdits($changedTokens);
     }
 
-    public function addFixableError($error, $stackPtr, $code, $data = array(), $severity = 0)
+    /**
+     * Attempts to record a message if we aren't actively ignoring it.
+     *
+     * @inheritDoc
+     */
+    protected function addMessage($error, $message, $line, $column, $code, $data, $severity, $fixable)
     {
-        if (isset($this->codeActionToken)) {
-            // We will assume that the error can be recorded because it wouldn't be in here otherwise.
-            return $this->codeActionToken === $stackPtr && $this->codeActionSource === $code;
+        // Check to see if we're only looking for a specific subset of messages.
+        $stackPtr = $this->getStackPtrForPosition($line, $column);
+        if (isset($stackPtr)) {
+            if (isset($this->codeActionToken)) {
+                // We will assume that the error can be recorded because it wouldn't be in here otherwise.
+                return $this->codeActionToken === $stackPtr && $this->codeActionSource === $code;
+            }
+
+            // Check the format range if one is set.
+            if (isset($this->formatStartToken) && $stackPtr < $this->formatStartToken) {
+                return false;
+            }
+            if (isset($this->formatEndToken) && $stackPtr > $this->formatEndToken) {
+                return false;
+            }
         }
 
-        // Check the format range if one is set.
-        if (isset($this->formatStartToken) && $stackPtr < $this->formatStartToken) {
-            return false;
-        }
-        if (isset($this->formatEndToken) && $stackPtr > $this->formatEndToken) {
-            return false;
-        }
-
-        return parent::addFixableError($error, $stackPtr, $code, $data, $severity);
-    }
-
-    public function addFixableWarning($warning, $stackPtr, $code, $data = array(), $severity = 0)
-    {
-        if (isset($this->codeActionToken)) {
-            // We will assume that the error can be recorded because it wouldn't be in here otherwise.
-            return $this->codeActionToken === $stackPtr && $this->codeActionSource === $code;
-        }
-
-        // Check the format range if one is set.
-        if (isset($this->formatStartToken) && $stackPtr < $this->formatStartToken) {
-            return false;
-        }
-        if (isset($this->formatEndToken) && $stackPtr > $this->formatEndToken) {
-            return false;
-        }
-
-        return parent::addFixableWarning($warning, $stackPtr, $code, $data, $severity);
+        return parent::addMessage($error, $message, $line, $column, $code, $data, $severity, $fixable);
     }
 
     /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

This pull request expands the token position map to include every character that is part of a token. Prior to this, "Format Selection" requests would only work on a problem if the first character of that problem was selected. Now, every selected character is considered.

Closes #46.

### How to test the changes in this Pull Request:

1. Open a file with problems.
2. Select some text other than the first character that the problem is associated with.
3. With this pull request, "Format Selection" will work as you expect it to. Without this pull request, it will do nothing.
