### PR TITLE
Now the plugin will try to find the .phpcs file in the parent folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Look into parent folders for the .phpcs files.
 
 ## [1.7.0] - 2022-07-29
 ### Added


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:
This PR makes the plugin look into the parent folders for the .phpcs files so it can use the project settings instead of only the standard settings.

### How to test the changes in this Pull Request:

1. Create a blank project 
2. Inside that project add a subfolder with a .phpcs.xml file
4. Add a php file to the subfolder
5. trigger a lint error that is present in the .phpcs.xml file you created and not in the standard 
6. move the .phpcs.xml file to the root folder
7. trigger the lint error again
8. remove the .phpcs.xml file and try to trigger the error again
