### PR TITLE
Added `Automatic` Standard Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `Automatic` option for `phpCodeSniffer.standard` that searches for a coding standard file
+(`phpcs.xml`, `.phpcs.xml`, `phpcs.dist.xml`, `.phpcs.dist.xml`). The search begins in the
+document's folder and traverses through parent directories until it reaches the workspace root.
 - `phpCodeSniffer.exec.linux`, `phpCodeSniffer.exec.osx`, and `phpCodeSniffer.exec.windows` options
 for platform-specific executables.
 - Support for execution on Windows without the use of WSL.
@@ -73,7 +76,7 @@ for platform-specific executables.
 
 ## [0.4.0] - 2021-02-21
 ### Added
-- Automatically attempt to find a `bin/phpcs` file in a vendor directory when `phpCodeSniffer.autoExecutable` is enabled.
+- Automatically attempt to find a `bin/phpcs` file in a vendor folder when `phpCodeSniffer.autoExecutable` is enabled.
 - Display PHPCS errors to the user.
 - Check document version before unnecessarily rebuilding diagnostics.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ This option will prevent the extension from linting any documents.
 
 Allow PHPCS to decide what standard should apply to the document. It will either use the default standard if one is configured, otherwise, it will try to find one in the workspace root and all parent directories.
 
+#### `Automatic`
+
+When selected, this option will cause the extension to search for an applicable coding standard file (`.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist`, `phpcs.xml.dist`). The extension starts in the document's directory and traverses through parent directories until it reaches the workspace root. If the extension fails to find a file it will do nothing and output an error.
+
 #### `Custom`
 
 This option will use the content of the `phpCodeSniffer.standardCustom` input as the standard. This can be the name of a custom ruleset, or, a path to a custom standard file. If a relative path is given it will be based

--- a/README.md
+++ b/README.md
@@ -12,10 +12,20 @@ _**Until you configure it, this extension will not lint any files.**_
 
 ### Standard (`phpCodeSniffer.standard`)
 
-This dropdown and accompanying text input allow you to define the standard or ruleset path to use. When set to
-`Default` we rely on PHPCS to decide on the standard based on its own configuration. When set to `Custom` we
-pass the content of `phpCodeSniffer.standardCustom` to PHPCS; allowing you to define a custom rulset name or
-use an XML file.
+This dropdown selects the coding standard that will be used. There are a few options that, when selected, will instead change the behavior of the extension.
+
+#### `Disabled`
+
+This option will prevent the extension from linting any documents.
+
+#### `Default`
+
+Allow PHPCS to decide what standard should apply to the document. It will either use the default standard if one is configured, otherwise, it will try to find one in the workspace root and all parent directories.
+
+#### `Custom`
+
+This option will use the content of the `phpCodeSniffer.standardCustom` input as the standard. This can be the name of a custom ruleset, or, a path to a custom standard file. If a relative path is given it will be based
+on the workspace root that the document resides in (untitled documents use the first root).
 
 ### Executable (`phpCodeSniffer.exec.linux`, `phpCodeSniffer.exec.osx`, and `phpCodeSniffer.exec.windows`)
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
           "enum": [
             "Disabled",
             "Default",
+            "Automatic",
             "PEAR",
             "MySource",
             "Squiz",
@@ -106,6 +107,7 @@
           "enumDescriptions": [
             "Disables the PHP_CodeSniffer extension's linting.",
             "Allows PHPCS to decide the coding standard.",
+            "Searches for a coding standard configuration file in the current document's directory and parent directories.",
             "Uses the PEAR coding standard.",
             "Uses the MySource coding standard.",
             "Uses the Squiz coding standard.",

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -7,7 +7,7 @@ const uriToString = (uri: any): string => {
 		str += '#' + uri.fragment;
 	}
 	return str;
-}
+};
 const Uri: any = jest.fn().mockImplementation(() => {
 	const created = {
 		scheme: 'file',
@@ -21,8 +21,9 @@ const Uri: any = jest.fn().mockImplementation(() => {
 	return created;
 });
 
-Uri.joinPath = jest.fn().mockImplementation(
-	(uri: any, ...pathSegments: string[]) => {
+Uri.joinPath = jest
+	.fn()
+	.mockImplementation((uri: any, ...pathSegments: string[]) => {
 		const uriSegments = uri.path.split('/');
 
 		for (const seg of pathSegments) {
@@ -50,8 +51,7 @@ Uri.joinPath = jest.fn().mockImplementation(
 			toString: () => uriToString(created),
 		};
 		return created;
-	}
-);
+	});
 
 const MockTextDocument = jest.fn().mockImplementation(() => {
 	return {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,3 +1,13 @@
+const uriToString = (uri: any): string => {
+	let str = uri.scheme + '://' + uri.path;
+	if (uri.query) {
+		str += '?' + uri.query;
+	}
+	if (uri.fragment) {
+		str += '#' + uri.fragment;
+	}
+	return str;
+}
 const Uri: any = jest.fn().mockImplementation(() => {
 	const created = {
 		scheme: 'file',
@@ -6,20 +16,42 @@ const Uri: any = jest.fn().mockImplementation(() => {
 		query: '',
 		fragment: '',
 		fsPath: 'test/file/path.php',
-		toString: (): string => {
-			let str = created.scheme + '://' + created.path;
-			if (created.query) {
-				str += '?' + created.query;
-			}
-			if (created.fragment) {
-				str += '#' + created.fragment;
-			}
-			return str;
-		},
+		toString: () => uriToString(created),
 	};
 	return created;
 });
-Uri.joinPath = jest.fn();
+
+Uri.joinPath = jest.fn().mockImplementation(
+	(uri: any, ...pathSegments: string[]) => {
+		const uriSegments = uri.path.split('/');
+
+		for (const seg of pathSegments) {
+			if (seg === '.') {
+				continue;
+			}
+
+			if (seg === '..') {
+				uriSegments.pop();
+				continue;
+			}
+
+			uriSegments.push(seg);
+		}
+
+		const path = uriSegments.join('/');
+
+		const created = {
+			scheme: uri.scheme,
+			authority: '',
+			fragment: '',
+			path: path,
+			query: '',
+			fsPath: path,
+			toString: () => uriToString(created),
+		};
+		return created;
+	}
+);
 
 const MockTextDocument = jest.fn().mockImplementation(() => {
 	return {

--- a/src/phpcs-report/__tests__/worker-integration.test.ts
+++ b/src/phpcs-report/__tests__/worker-integration.test.ts
@@ -3,7 +3,6 @@ import * as child_process from 'child_process';
 import { Request } from '../request';
 import { ReportType } from '../response';
 import { WorkerPool } from '../worker-pool';
-import { StandardType } from '../../services/configuration';
 import { CancellationError } from 'vscode';
 import { MockCancellationToken } from '../../__mocks__/vscode';
 
@@ -53,7 +52,7 @@ describe('Worker/WorkerPool Integration', () => {
 				options: {
 					workingDirectory: __dirname,
 					executable: phpcsPath,
-					standard: StandardType.PSR12,
+					standard: 'PSR12',
 				},
 				data: null,
 			};
@@ -81,7 +80,7 @@ describe('Worker/WorkerPool Integration', () => {
 				options: {
 					workingDirectory: __dirname,
 					executable: phpcsPath,
-					standard: StandardType.PSR12,
+					standard: 'PSR12',
 				},
 				data: null,
 			};

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -1,7 +1,6 @@
 import * as child_process from 'child_process';
 import { resolve as resolvePath } from 'path';
 import { CancellationError } from 'vscode';
-import { StandardType } from '../../services/configuration';
 import { MockCancellationToken } from '../../__mocks__/vscode';
 import { Request } from '../request';
 import { ReportType } from '../response';
@@ -52,7 +51,7 @@ describe('Worker', () => {
 			options: {
 				workingDirectory: __dirname,
 				executable: phpcsPath,
-				standard: StandardType.PSR12,
+				standard: 'PSR12',
 			},
 			data: null,
 		};
@@ -74,7 +73,7 @@ describe('Worker', () => {
 			options: {
 				workingDirectory: __dirname,
 				executable: phpcsPath,
-				standard: StandardType.PSR12,
+				standard: 'PSR12',
 			},
 			data: null,
 		};
@@ -98,7 +97,7 @@ describe('Worker', () => {
 			options: {
 				workingDirectory: __dirname,
 				executable: phpcsPath,
-				standard: StandardType.PSR12,
+				standard: 'PSR12',
 			},
 			data: {
 				code: 'PSR12.Files.OpenTag.NotAlone',
@@ -138,7 +137,7 @@ describe('Worker', () => {
 			options: {
 				workingDirectory: __dirname,
 				executable: phpcsPath,
-				standard: StandardType.PSR12,
+				standard: 'PSR12',
 			},
 			data: {},
 		};
@@ -160,7 +159,7 @@ describe('Worker', () => {
 			options: {
 				workingDirectory: __dirname,
 				executable: phpcsPath,
-				standard: StandardType.PSR12,
+				standard: 'PSR12',
 			},
 			data: null,
 		};
@@ -186,7 +185,7 @@ describe('Worker', () => {
 			options: {
 				workingDirectory: __dirname,
 				executable: phpcsPath,
-				standard: StandardType.PSR12,
+				standard: 'PSR12',
 			},
 			data: null,
 		};
@@ -208,7 +207,7 @@ describe('Worker', () => {
 				workingDirectory: __dirname,
 				// Since we use custom reports, adding `-s` for sources won't break anything.
 				executable: phpcsPath + ' -s',
-				standard: StandardType.PSR12,
+				standard: 'PSR12',
 			},
 			data: null,
 		};

--- a/src/phpcs-report/request.ts
+++ b/src/phpcs-report/request.ts
@@ -6,7 +6,7 @@ import { ReportType } from './response';
 export interface RequestOptions {
 	workingDirectory: string;
 	executable: string;
-	standard: string;
+	standard: string | null;
 }
 
 /**

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -1,7 +1,6 @@
 import { ChildProcess, spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import { resolve as resolvePath } from 'path';
 import { CancellationError, CancellationToken, Disposable } from 'vscode';
-import { StandardType } from '../services/configuration';
 import { Request } from './request';
 import { ReportType, Response } from './response';
 
@@ -93,7 +92,7 @@ export class Worker {
 		return new Promise<Response<T>>((resolve, reject) => {
 			// Under certain circumstances we shouldn't bother generating a report because it will be empty.
 			if (
-				request.options.standard === 'Disabled' ||
+				!request.options.standard ||
 				request.documentContent.length <= 0
 			) {
 				resolve(Response.empty(request.type));
@@ -200,7 +199,7 @@ export class Worker {
 		processArguments.unshift(...executableMatches);
 
 		// Only set the standard when the user has selected one.
-		if (request.options.standard !== StandardType.Default) {
+		if (request.options.standard) {
 			processArguments.push('--standard=' + request.options.standard);
 		}
 

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -30,8 +30,8 @@ type ConfigurationType = {
 	standardCustom: string;
 
 	// Deprecated Options
-	executable: string | null,
-	ignorePatterns: string[] | null,
+	executable: string | null;
+	ignorePatterns: string[] | null;
 };
 
 /**

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -20,14 +20,14 @@ import {
  * The default configuration options to use in our tests.
  */
 type ConfigurationType = {
-	autoExecutable: boolean,
-	'exec.linux': string,
-	'exec.osx': string,
-	'exec.windows': string,
-	exclude: string[],
-	lintAction: LintAction,
-	standard: SpecialStandardOptions | string,
-	standardCustom: string,
+	autoExecutable: boolean;
+	'exec.linux': string;
+	'exec.osx': string;
+	'exec.windows': string;
+	exclude: string[];
+	lintAction: LintAction;
+	standard: SpecialStandardOptions | string;
+	standardCustom: string;
 
 	// Deprecated Options
 	executable: string | null,
@@ -244,14 +244,12 @@ describe('Configuration', () => {
 	describe('should parse `standard` option', () => {
 		it('disabled', async () => {
 			const mockConfiguration = {
-				get: jest.fn().mockImplementation(
-					getDefaultConfiguration()
-				),
+				get: jest.fn().mockImplementation(getDefaultConfiguration()),
 			};
 			jest.mocked(workspace).getConfiguration.mockReturnValue(
 				mockConfiguration as never
 			);
-	
+
 			const result = await configuration.get(mockDocument);
 
 			expect(workspace.getConfiguration).toHaveBeenCalledWith(
@@ -277,7 +275,7 @@ describe('Configuration', () => {
 			jest.mocked(workspace).getConfiguration.mockReturnValue(
 				mockConfiguration as never
 			);
-	
+
 			const result = await configuration.get(mockDocument);
 
 			expect(workspace.getConfiguration).toHaveBeenCalledWith(
@@ -304,7 +302,7 @@ describe('Configuration', () => {
 			jest.mocked(workspace).getConfiguration.mockReturnValue(
 				mockConfiguration as never
 			);
-	
+
 			const result = await configuration.get(mockDocument);
 
 			expect(workspace.getConfiguration).toHaveBeenCalledWith(
@@ -330,7 +328,7 @@ describe('Configuration', () => {
 			jest.mocked(workspace).getConfiguration.mockReturnValue(
 				mockConfiguration as never
 			);
-	
+
 			const result = await configuration.get(mockDocument);
 
 			expect(workspace.getConfiguration).toHaveBeenCalledWith(
@@ -359,12 +357,17 @@ describe('Configuration', () => {
 				jest.mocked(workspace).fs.stat.mockImplementation((uri) => {
 					switch (uri.path) {
 						case 'test/file/phpcs.xml':
-							return Promise.resolve({ type: 0, ctime: 0, mtime: 0, size: 0 });
+							return Promise.resolve({
+								type: 0,
+								ctime: 0,
+								mtime: 0,
+								size: 0,
+							});
 					}
-	
+
 					throw new Error('Invalid path: ' + uri.path);
 				});
-				
+
 				const mockConfiguration = {
 					get: jest.fn().mockImplementation(
 						getDefaultConfiguration({
@@ -375,9 +378,9 @@ describe('Configuration', () => {
 				jest.mocked(workspace).getConfiguration.mockReturnValue(
 					mockConfiguration as never
 				);
-		
+
 				const result = await configuration.get(mockDocument);
-	
+
 				expect(workspace.getConfiguration).toHaveBeenCalledWith(
 					'phpCodeSniffer',
 					mockDocument
@@ -404,9 +407,14 @@ describe('Configuration', () => {
 							return Promise.reject(new FileSystemError(uri));
 
 						case 'test/.phpcs.xml':
-							return Promise.resolve({ type: 0, ctime: 0, mtime: 0, size: 0 });
+							return Promise.resolve({
+								type: 0,
+								ctime: 0,
+								mtime: 0,
+								size: 0,
+							});
 					}
-	
+
 					throw new Error('Invalid path: ' + uri.path);
 				});
 
@@ -420,9 +428,9 @@ describe('Configuration', () => {
 				jest.mocked(workspace).getConfiguration.mockReturnValue(
 					mockConfiguration as never
 				);
-		
+
 				const result = await configuration.get(mockDocument);
-	
+
 				expect(workspace.getConfiguration).toHaveBeenCalledWith(
 					'phpCodeSniffer',
 					mockDocument
@@ -471,7 +479,7 @@ describe('Configuration', () => {
 			const mockConfiguration = {
 				get: jest.fn().mockImplementation(
 					getDefaultConfiguration({
-						executable: 'test.override'
+						executable: 'test.override',
 					})
 				),
 			};

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -9,10 +9,7 @@ import {
 } from 'vscode';
 import { resolve as resolvePath } from 'path';
 import { CodeAction, CodeActionCollection } from '../../types';
-import {
-	Configuration,
-	LintAction,
-} from '../../services/configuration';
+import { Configuration, LintAction } from '../../services/configuration';
 import { WorkerPool } from '../../phpcs-report/worker-pool';
 import { DiagnosticUpdater } from '../diagnostic-updater';
 import {

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -12,7 +12,6 @@ import { CodeAction, CodeActionCollection } from '../../types';
 import {
 	Configuration,
 	LintAction,
-	StandardType,
 } from '../../services/configuration';
 import { WorkerPool } from '../../phpcs-report/worker-pool';
 import { DiagnosticUpdater } from '../diagnostic-updater';
@@ -96,7 +95,7 @@ describe('DiagnosticUpdater', () => {
 			executable: 'phpcs-test',
 			exclude: [],
 			lintAction: LintAction.Change,
-			standard: StandardType.PSR12,
+			standard: 'PSR12',
 		});
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
@@ -104,7 +103,7 @@ describe('DiagnosticUpdater', () => {
 				options: {
 					workingDirectory: 'test-dir',
 					executable: 'phpcs-test',
-					standard: StandardType.PSR12,
+					standard: 'PSR12',
 				},
 			});
 
@@ -153,7 +152,7 @@ describe('DiagnosticUpdater', () => {
 			executable: 'phpcs-test',
 			exclude: [],
 			lintAction: LintAction.Change,
-			standard: StandardType.PSR12,
+			standard: 'PSR12',
 		});
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
@@ -161,7 +160,7 @@ describe('DiagnosticUpdater', () => {
 				options: {
 					workingDirectory: 'test-dir',
 					executable: 'phpcs-test',
-					standard: StandardType.PSR12,
+					standard: 'PSR12',
 				},
 			});
 
@@ -186,7 +185,7 @@ describe('DiagnosticUpdater', () => {
 			executable: 'phpcs-test',
 			exclude: [new RegExp('.*/file/.*')],
 			lintAction: LintAction.Change,
-			standard: StandardType.PSR12,
+			standard: 'PSR12',
 		});
 
 		return diagnosticUpdater.update(document, LintAction.Force);
@@ -201,7 +200,7 @@ describe('DiagnosticUpdater', () => {
 			executable: 'phpcs-test',
 			exclude: [],
 			lintAction: LintAction.Save,
-			standard: StandardType.PSR12,
+			standard: 'PSR12',
 		});
 
 		return diagnosticUpdater.update(document, LintAction.Change);

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -109,6 +109,16 @@ export interface DocumentConfiguration {
 type FolderTraversalCallback<T> = (folderUri: Uri) => Promise<T | false>;
 
 /**
+ * The valid filenames we look for when automatically searching for coding standards.
+ */
+export const AutomaticCodingStandardFilenames = [
+	'phpcs.xml',
+	'.phpcs.xml',
+	'phpcs.dist.xml',
+	'.phpcs.dist.xml',
+];
+
+/**
  * A class for reading our configuration.
  */
 export class Configuration {
@@ -361,9 +371,7 @@ export class Configuration {
 			cancellationToken
 		);
 		if (parsed === false) {
-			throw new Error(
-				'The extension failed to find a coding standard file.'
-			);
+			return null;
 		}
 
 		return parsed;
@@ -498,20 +506,13 @@ export class Configuration {
 	 * @param {Uri} folder The folder we're checking for a coding standard file.
 	 */
 	private async findCodingStandardFile(folder: Uri): Promise<string | false> {
-		// We should examine a few possible filenames.
-		const filenames = [
-			'phpcs.xml',
-			'.phpcs.xml',
-			'phpcs.dist.xml',
-			'.phpcs.dist.xml',
-		];
-
-		for (const filename of filenames) {
+		// Look for any of the valid coding standard filenames.
+		for (const filename of AutomaticCodingStandardFilenames) {
 			try {
 				// The stat() call will throw an error if the file could not be found.
 				const codingStandardPath = Uri.joinPath(folder, filename);
 				await this.workspace.fs.stat(codingStandardPath);
-	
+
 				return codingStandardPath.fsPath;
 			} catch (e) {
 				// Only errors from the filesystem are relevant.


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

This pull request adds a new `Automatic` option for `phpCodeSniffer.standard`. When this new option is used the extension will attempt to find one of the configuration file types that we've defined. It will traverse from the document's directory to the workspace root seeking out an appropriate file.

As part of this work I also went ahead and refactored the way that the standard works a little bit. There's no longer a need to check for type strings and I've removed the `StandardType` enum entirely.

Closes #59.

### How to test the changes in this Pull Request:

1. Set `phpCodeSniffer.standard` to `Automatic` in the settings.
2. Create a workspace that has both a root `phpcs.xml` file and a `phpcs.xml` file in a nested directory.
3. Create a PHP file in the nested directory and make sure it violates the nested coding standard but not the one at the root.
4. Delete the nested coding standard and the errors should go away.
5. Rename the root file to `.phpcs.xml` and verify that it still works.
