### PR TITLE
Add Windows Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `phpCodeSniffer.executable.linux`, `phpCodeSniffer.executable.osx`, and `phpCodeSniffer.executable.windows` options
+for platform-specific executables.
+
+### Deprecated
+- `phpCodeSniffer.executable` has been deprecated in favor of using platform-specific executables.
 
 ## [1.7.0] - 2022-07-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `phpCodeSniffer.exec.linux`, `phpCodeSniffer.exec.osx`, and `phpCodeSniffer.exec.windows` options
 for platform-specific executables.
+- Support for execution on Windows without the use of WSL.
 
 ### Deprecated
 - `phpCodeSniffer.executable` has been deprecated in favor of using platform-specific executables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `phpCodeSniffer.executable.linux`, `phpCodeSniffer.executable.osx`, and `phpCodeSniffer.executable.windows` options
+- `phpCodeSniffer.exec.linux`, `phpCodeSniffer.exec.osx`, and `phpCodeSniffer.exec.windows` options
 for platform-specific executables.
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ This dropdown and accompanying text input allow you to define the standard or ru
 pass the content of `phpCodeSniffer.standardCustom` to PHPCS; allowing you to define a custom rulset name or
 use an XML file.
 
-### Executable (`phpCodeSniffer.executable.linux`, `phpCodeSniffer.executable.osx`, and `phpCodeSniffer.executable.windows`)
+### Executable (`phpCodeSniffer.exec.linux`, `phpCodeSniffer.exec.osx`, and `phpCodeSniffer.exec.windows`)
 
 This text input allows for setting a path to a platform-specific PHPCS executable. If a relative path is given it will be
 based on the workspace root that the document resides in (untitled documents use the first root). You may also set the
 `phpCodeSniffer.autoExecutable` option if you'd like for the extension to automatically search for an executable. This
-works by looking for a `{vendor-dir}/bin/phpcs` (`phpcs.bat` on Windows) file in the document's directory and then
+works by looking for a `{vendor-dir}/bin/phpcs` (`{vendor-dir}\bin\phpcs.bat` on Windows) file in the document's directory and then
 traversing up to the workspace folder if it does not find one. When it fails to find one automatically it will
 fall back to the explicit option.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Integrates [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) into VS Code.
 
-This extension uses the version of PHPCS defined by the `phpCodeSniffer.executable` setting. Through the use of
+This extension uses the version of PHPCS defined by the platform-specific executable setting. Through the use of
 custom reports we are able to generate diagnostics, code actions, and document formatting that fully utilizes
 VS Code's available features.
 
@@ -17,15 +17,16 @@ This dropdown and accompanying text input allow you to define the standard or ru
 pass the content of `phpCodeSniffer.standardCustom` to PHPCS; allowing you to define a custom rulset name or
 use an XML file.
 
-### Executable (`phpCodeSniffer.executable`)
+### Executable (`phpCodeSniffer.executable.linux`, `phpCodeSniffer.executable.osx`, and `phpCodeSniffer.executable.windows`)
 
-This text input allows for setting a path to a PHPCS executable. If a relative path is given it will be based
-on the workspace root that the document resides in (untitled documents use the first root). You may also set
-the `phpCodeSniffer.autoExecutable` option if you'd like for the extension to automatically search for an
-executable. This works by looking for a `{vendor-dir}/bin/phpcs` file in the document's directory and then
-traversing up to the workspace folder if it does not find one. When it fails to find one automatically it
-will fall back to the explicit option.
+This text input allows for setting a path to a platform-specific PHPCS executable. If a relative path is given it will be
+based on the workspace root that the document resides in (untitled documents use the first root). You may also set the
+`phpCodeSniffer.autoExecutable` option if you'd like for the extension to automatically search for an executable. This
+works by looking for a `{vendor-dir}/bin/phpcs` (`phpcs.bat` on Windows) file in the document's directory and then
+traversing up to the workspace folder if it does not find one. When it fails to find one automatically it will
+fall back to the explicit option.
 
 ### File and Folder Exclusions (`phpCodeSniffer.exclude`)
 
-This array of glob patterns allows you to exclude files and folders from linting. While the extension **does** respect any file rules in your coding standard, this option allows you to define additional rules.
+This array of glob patterns allows you to exclude files and folders from linting. While the extension **does** respect
+any file rules in your coding standard, this option allows you to define additional rules.

--- a/package.json
+++ b/package.json
@@ -42,27 +42,27 @@
       "properties": {
         "phpCodeSniffer.autoExecutable": {
           "type": "boolean",
-          "markdownDescription": "Attempts to find `bin/phpcs` in the file directory and parent directories' vendor directory before falling back to `#phpCodeSniffer.executable#`.",
+          "markdownDescription": "Attempts to find `bin/phpcs` in the file directory and parent directories' vendor directory before falling back to the platform-specific executable.",
           "default": false,
           "scope": "resource"
         },
-        "phpCodeSniffer.executable": {
+        "phpCodeSniffer.executable.linux": {
           "type": "string",
-          "markdownDescription": "The path to the PHPCS executable we want to use when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
+          "markdownDescription": "The path to the PHPCS executable we want to use on Linux when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
           "default": "phpcs",
           "scope": "machine-overridable"
         },
-        "phpCodeSniffer.ignorePatterns": {
-          "type": "array",
-          "description": "An array of regular expressions for paths that should be ignored by the extension.",
-          "markdownDeprecationMessage": "File and folder exclusions should use glob patterns in `#phpCodeSniffer.exclude#` instead.",
-          "default": [
-            ".*/vendor/.*"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "scope": "window"
+        "phpCodeSniffer.executable.osx": {
+          "type": "string",
+          "markdownDescription": "The path to the PHPCS executable we want to use on OSX when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
+          "default": "phpcs",
+          "scope": "machine-overridable"
+        },
+        "phpCodeSniffer.executable.windows": {
+          "type": "string",
+          "markdownDescription": "The path to the PHPCS executable we want to use on Windows when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
+          "default": "phpcs.bat",
+          "scope": "machine-overridable"
         },
         "phpCodeSniffer.exclude": {
           "type": "array",
@@ -119,6 +119,25 @@
           "type": "string",
           "markdownDescription": "The custom coding standard to use if `#phpCodeSniffer.standard#` is set to 'Custom'.",
           "default": "",
+          "scope": "window"
+        },
+        "phpCodeSniffer.executable": {
+          "type": "string",
+          "markdownDescription": "The path to the PHPCS executable we want to use when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
+          "markdownDeprecationMessage": "Executables are now be platform-specific; use `#phpCodeSniffer.executable.linux#`, `#phpCodeSniffer.executable.osx#`, or `#phpCodeSniffer.executable.windows#` instead.",
+          "default": "phpcs",
+          "scope": "machine-overridable"
+        },
+        "phpCodeSniffer.ignorePatterns": {
+          "type": "array",
+          "description": "An array of regular expressions for paths that should be ignored by the extension.",
+          "markdownDeprecationMessage": "File and folder exclusions should use glob patterns in `#phpCodeSniffer.exclude#` instead.",
+          "default": [
+            ".*/vendor/.*"
+          ],
+          "items": {
+            "type": "string"
+          },
           "scope": "window"
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,19 +46,19 @@
           "default": false,
           "scope": "resource"
         },
-        "phpCodeSniffer.executable.linux": {
+        "phpCodeSniffer.exec.linux": {
           "type": "string",
           "markdownDescription": "The path to the PHPCS executable we want to use on Linux when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
           "default": "phpcs",
           "scope": "machine-overridable"
         },
-        "phpCodeSniffer.executable.osx": {
+        "phpCodeSniffer.exec.osx": {
           "type": "string",
           "markdownDescription": "The path to the PHPCS executable we want to use on OSX when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
           "default": "phpcs",
           "scope": "machine-overridable"
         },
-        "phpCodeSniffer.executable.windows": {
+        "phpCodeSniffer.exec.windows": {
           "type": "string",
           "markdownDescription": "The path to the PHPCS executable we want to use on Windows when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
           "default": "phpcs.bat",
@@ -124,7 +124,7 @@
         "phpCodeSniffer.executable": {
           "type": "string",
           "markdownDescription": "The path to the PHPCS executable we want to use when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
-          "markdownDeprecationMessage": "Executables are now be platform-specific; use `#phpCodeSniffer.executable.linux#`, `#phpCodeSniffer.executable.osx#`, or `#phpCodeSniffer.executable.windows#` instead.",
+          "markdownDeprecationMessage": "Executables are now be platform-specific; use `#phpCodeSniffer.exec.linux#`, `#phpCodeSniffer.exec.osx#`, or `#phpCodeSniffer.exec.windows#` instead.",
           "default": "phpcs",
           "scope": "machine-overridable"
         },

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -207,8 +207,8 @@ describe('Worker', () => {
 			documentContent: '<?php class Test {}',
 			options: {
 				workingDirectory: __dirname,
-				// Adding the PHP executable won't break the PHPCS script.
-				executable: '/usr/bin/env php ' + phpcsPath,
+				// Since we use custom reports, adding `-s` for sources won't break anything.
+				executable: phpcsPath + ' -s',
 				standard: StandardType.PSR12,
 			},
 			data: null,

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -273,6 +273,15 @@ export class Worker {
 
 		// Send the document to be handled.
 		if (phpcsProcess.stdin.writable) {
+			// Buffer the input so that Windows' blocking read will pull everything.
+			phpcsProcess.stdin.cork();
+
+			// Write the input file path before the content so PHPCS can utilize it.
+			phpcsProcess.stdin.write(
+				'phpcs_input_file: ' + request.documentPath + '\n'
+			);
+
+			// Write out the file content now and close the input.
 			phpcsProcess.stdin.end(request.documentContent);
 		}
 

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -214,7 +214,7 @@ export class Worker {
 					data: request.data,
 				}),
 			},
-			windowsHide: true
+			windowsHide: true,
 		};
 
 		// Give the working directory when requested.

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -216,6 +216,11 @@ export class Worker {
 			},
 		};
 
+		// We need to run the command through a shell on Windows to handle batch files.
+		if (process.platform === 'win32') {
+			processOptions.shell = true;
+		}
+
 		// Give the working directory when requested.
 		if (request.options.workingDirectory) {
 			processOptions.cwd = request.options.workingDirectory;
@@ -269,14 +274,11 @@ export class Worker {
 
 		// Send the document to be handled.
 		if (phpcsProcess.stdin.writable) {
-			console.log('Writing File Content');
 			// Write the input file path before the content so PHPCS can utilize it.
 			phpcsProcess.stdin.write(
 				'phpcs_input_file: ' + request.documentPath + '\n'
 			);
 			phpcsProcess.stdin.end(request.documentContent);
-		} else {
-			console.log('Did Not Write File Content');
 		}
 
 		// Clear the content to free memory as we don't need it anymore.

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -216,15 +216,13 @@ export class Worker {
 			},
 		};
 
-		// We need to run the command through a shell on Windows to handle batch files.
-		if (process.platform === 'win32') {
-			processOptions.shell = true;
-		}
-
 		// Give the working directory when requested.
 		if (request.options.workingDirectory) {
 			processOptions.cwd = request.options.workingDirectory;
 		}
+
+		// Make sure PHPCS knows to read from STDIN.
+		processArguments.push('-');
 
 		// Create a new process to fetch the report.
 		const phpcsProcess = spawn(

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -214,6 +214,7 @@ export class Worker {
 					data: request.data,
 				}),
 			},
+			shell: true,
 		};
 
 		// Give the working directory when requested.

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -214,7 +214,7 @@ export class Worker {
 					data: request.data,
 				}),
 			},
-			shell: true,
+			windowsHide: true
 		};
 
 		// Give the working directory when requested.
@@ -277,7 +277,7 @@ export class Worker {
 			phpcsProcess.stdin.write(
 				'phpcs_input_file: ' + request.documentPath + '\n'
 			);
-			phpcsProcess.stdin.end(request.documentContent);
+			//phpcsProcess.stdin.end(request.documentContent);
 		}
 
 		// Clear the content to free memory as we don't need it anymore.

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -269,11 +269,14 @@ export class Worker {
 
 		// Send the document to be handled.
 		if (phpcsProcess.stdin.writable) {
+			console.log('Writing File Content');
 			// Write the input file path before the content so PHPCS can utilize it.
 			phpcsProcess.stdin.write(
 				'phpcs_input_file: ' + request.documentPath + '\n'
 			);
 			phpcsProcess.stdin.end(request.documentContent);
+		} else {
+			console.log('Did Not Write File Content');
 		}
 
 		// Clear the content to free memory as we don't need it anymore.

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -273,11 +273,7 @@ export class Worker {
 
 		// Send the document to be handled.
 		if (phpcsProcess.stdin.writable) {
-			// Write the input file path before the content so PHPCS can utilize it.
-			phpcsProcess.stdin.write(
-				'phpcs_input_file: ' + request.documentPath + '\n'
-			);
-			//phpcsProcess.stdin.end(request.documentContent);
+			phpcsProcess.stdin.end(request.documentContent);
 		}
 
 		// Clear the content to free memory as we don't need it anymore.

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -66,8 +66,10 @@ describe('Configuration', () => {
 			switch (key) {
 				case 'autoExecutable':
 					return false;
-				case 'executable':
-					return 'test.exec';
+				case 'executable.linux':
+				case 'executable.osx':
+				case 'executable.windows':
+					return 'test.platform';
 				case 'exclude':
 					return ['test/{test|test-test}/*.php'];
 				case 'lintAction':
@@ -76,6 +78,7 @@ describe('Configuration', () => {
 					return StandardType.Disabled;
 
 				// Deprecated options.
+				case 'executable':
 				case 'ignorePatterns':
 					return undefined;
 			}
@@ -93,7 +96,7 @@ describe('Configuration', () => {
 		);
 		expect(result).toMatchObject({
 			workingDirectory: 'test/file',
-			executable: 'test.exec',
+			executable: 'test.platform',
 			exclude: [/^(?:test\/\\{test|test-test}\/(?!\.)(?=.)[^/]*?\.php)$/],
 			standard: StandardType.Disabled,
 		});
@@ -154,8 +157,10 @@ describe('Configuration', () => {
 			switch (key) {
 				case 'autoExecutable':
 					return true;
-				case 'executable':
-					return 'test.exec';
+				case 'executable.linux':
+				case 'executable.osx':
+				case 'executable.windows':
+					return 'test.platform';
 				case 'exclude':
 					return [];
 				case 'lintAction':
@@ -164,6 +169,7 @@ describe('Configuration', () => {
 					return StandardType.Disabled;
 
 				// Deprecated settings.
+				case 'executable':
 				case 'ignorePatterns':
 					return undefined;
 			}
@@ -244,8 +250,10 @@ describe('Configuration', () => {
 			switch (key) {
 				case 'autoExecutable':
 					return true;
-				case 'executable':
-					return 'test.exec';
+				case 'executable.linux':
+				case 'executable.osx':
+				case 'executable.windows':
+					return 'test.platform';
 				case 'exclude':
 					return ['test/{test|test-test}/*.php'];
 				case 'lintAction':
@@ -254,6 +262,8 @@ describe('Configuration', () => {
 					return StandardType.Disabled;
 
 				// Deprecated settings.
+				case 'executable':
+					return undefined;
 				case 'ignorePatterns':
 					return undefined;
 			}
@@ -272,6 +282,55 @@ describe('Configuration', () => {
 	});
 
 	describe('deprecated options', () => {
+		it('should handle "executable" deprecation', async () => {
+			const mockConfiguration = { get: jest.fn() };
+			jest.mocked(workspace).getConfiguration.mockReturnValue(
+				mockConfiguration as never
+			);
+
+			mockConfiguration.get.mockImplementation((key) => {
+				switch (key) {
+					case 'autoExecutable':
+						return false;
+					case 'executable.linux':
+					case 'executable.osx':
+					case 'executable.windows':
+						return 'test.platform';
+					case 'exclude':
+						return [];
+					case 'lintAction':
+						return LintAction.Change;
+					case 'standard':
+						return StandardType.Disabled;
+
+					// Deprecated options.
+					case 'executable':
+						return 'test.exec';
+					case 'ignorePatterns':
+						return undefined;
+				}
+
+				fail(
+					'An unexpected configuration key of ' +
+						key +
+						' was received.'
+				);
+			});
+
+			const result = await configuration.get(mockDocument);
+
+			expect(workspace.getConfiguration).toHaveBeenCalledWith(
+				'phpCodeSniffer',
+				mockDocument
+			);
+			expect(result).toMatchObject({
+				workingDirectory: 'test',
+				executable: 'test.exec',
+				exclude: [],
+				standard: StandardType.Disabled,
+			});
+		});
+
 		it('should handle "ignorePatterns" deprecation', async () => {
 			const mockConfiguration = { get: jest.fn() };
 			jest.mocked(workspace).getConfiguration.mockReturnValue(
@@ -282,8 +341,10 @@ describe('Configuration', () => {
 				switch (key) {
 					case 'autoExecutable':
 						return false;
-					case 'executable':
-						return 'test.exec';
+					case 'executable.linux':
+					case 'executable.osx':
+					case 'executable.windows':
+						return 'test.platform';
 					case 'exclude':
 						return ['test/{test|test-test}/*.php'];
 					case 'lintAction':
@@ -292,6 +353,8 @@ describe('Configuration', () => {
 						return StandardType.Disabled;
 
 					// Deprecated options.
+					case 'executable':
+						return undefined;
 					case 'ignorePatterns':
 						return ['test'];
 				}
@@ -311,7 +374,7 @@ describe('Configuration', () => {
 			);
 			expect(result).toMatchObject({
 				workingDirectory: 'test',
-				executable: 'test.exec',
+				executable: 'test.platform',
 				exclude: [
 					/^(?:test\/\\{test|test-test}\/(?!\.)(?=.)[^/]*?\.php)$/,
 					/test/,

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -126,7 +126,7 @@ describe('Configuration', () => {
 			switch (uri.path) {
 				case 'test/file/composer.json':
 					return Promise.reject(new FileSystemError(uri));
-				case 'test/composer.json': {
+				case 'test/composer.json':
 					const json = JSON.stringify({
 						config: {
 							'vendor-dir': 'newvendor',
@@ -134,7 +134,6 @@ describe('Configuration', () => {
 					});
 					const encoder = new TextEncoder();
 					return Promise.resolve(encoder.encode(json));
-				}
 			}
 
 			throw new Error('Invalid path: ' + uri.path);
@@ -142,12 +141,12 @@ describe('Configuration', () => {
 
 		jest.mocked(workspace.fs.stat).mockImplementation((uri) => {
 			switch (uri.path) {
-				case 'test/newvendor/bin/phpcs': {
+				case 'test/newvendor/bin/phpcs.bat':
+				case 'test/newvendor/bin/phpcs':
 					const ret = new Uri();
 					ret.path = 'test';
 					ret.fsPath = 'test';
 					return Promise.resolve(ret);
-				}
 			}
 
 			throw new Error('Invalid path: ' + uri.path);
@@ -187,7 +186,7 @@ describe('Configuration', () => {
 		);
 		expect(result).toMatchObject({
 			workingDirectory: 'test',
-			executable: 'test/newvendor/bin/phpcs',
+			executable: process.platform === 'win32' ? 'test/newvendor/bin/phpcs.bat' : 'test/newvendor/bin/phpcs',
 			exclude: [],
 			standard: StandardType.Disabled,
 		});
@@ -219,7 +218,7 @@ describe('Configuration', () => {
 			switch (uri.path) {
 				case 'test/file/composer.json':
 					return Promise.reject(new FileSystemError(uri));
-				case 'test/composer.json': {
+				case 'test/composer.json':
 					const json = JSON.stringify({
 						config: {
 							'vendor-dir': 'newvendor',
@@ -227,7 +226,6 @@ describe('Configuration', () => {
 					});
 					const encoder = new TextEncoder();
 					return Promise.resolve(encoder.encode(json));
-				}
 			}
 
 			throw new Error('Invalid path: ' + uri.path);
@@ -235,12 +233,12 @@ describe('Configuration', () => {
 
 		jest.mocked(workspace.fs.stat).mockImplementation((uri) => {
 			switch (uri.path) {
-				case 'test/newvendor/bin/phpcs': {
+				case 'test/newvendor/bin/phpcs.bat':
+				case 'test/newvendor/bin/phpcs':
 					const ret = new Uri();
 					ret.path = 'test';
 					ret.fsPath = 'test';
 					return Promise.resolve(ret);
-				}
 			}
 
 			throw new Error('Invalid path: ' + uri.path);

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -68,9 +68,9 @@ describe('Configuration', () => {
 			switch (key) {
 				case 'autoExecutable':
 					return false;
-				case 'executable.linux':
-				case 'executable.osx':
-				case 'executable.windows':
+				case 'exec.linux':
+				case 'exec.osx':
+				case 'exec.windows':
 					return 'test.platform';
 				case 'exclude':
 					return ['test/{test|test-test}/*.php'];
@@ -161,9 +161,9 @@ describe('Configuration', () => {
 			switch (key) {
 				case 'autoExecutable':
 					return true;
-				case 'executable.linux':
-				case 'executable.osx':
-				case 'executable.windows':
+				case 'exec.linux':
+				case 'exec.osx':
+				case 'exec.windows':
 					return 'test.platform';
 				case 'exclude':
 					return [];
@@ -259,9 +259,9 @@ describe('Configuration', () => {
 			switch (key) {
 				case 'autoExecutable':
 					return true;
-				case 'executable.linux':
-				case 'executable.osx':
-				case 'executable.windows':
+				case 'exec.linux':
+				case 'exec.osx':
+				case 'exec.windows':
 					return 'test.platform';
 				case 'exclude':
 					return ['test/{test|test-test}/*.php'];
@@ -301,9 +301,9 @@ describe('Configuration', () => {
 				switch (key) {
 					case 'autoExecutable':
 						return false;
-					case 'executable.linux':
-					case 'executable.osx':
-					case 'executable.windows':
+					case 'exec.linux':
+					case 'exec.osx':
+					case 'exec.windows':
 						return 'test.platform';
 					case 'exclude':
 						return [];
@@ -350,9 +350,9 @@ describe('Configuration', () => {
 				switch (key) {
 					case 'autoExecutable':
 						return false;
-					case 'executable.linux':
-					case 'executable.osx':
-					case 'executable.windows':
+					case 'exec.linux':
+					case 'exec.osx':
+					case 'exec.windows':
 						return 'test.platform';
 					case 'exclude':
 						return ['test/{test|test-test}/*.php'];

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -16,6 +16,7 @@ import { Configuration, LintAction, StandardType } from '../configuration';
 describe('Configuration', () => {
 	let mockDocument: TextDocument;
 	let configuration: Configuration;
+	let textEncoder: TextEncoder;
 
 	beforeAll(() => {
 		// Create a mock implementation that can create joined paths.
@@ -49,6 +50,7 @@ describe('Configuration', () => {
 	beforeEach(() => {
 		mockDocument = new MockTextDocument();
 		configuration = new Configuration(workspace);
+		textEncoder = new TextEncoder();
 	});
 
 	afterEach(() => {
@@ -127,13 +129,15 @@ describe('Configuration', () => {
 				case 'test/file/composer.json':
 					return Promise.reject(new FileSystemError(uri));
 				case 'test/composer.json':
-					const json = JSON.stringify({
-						config: {
-							'vendor-dir': 'newvendor',
-						},
-					});
-					const encoder = new TextEncoder();
-					return Promise.resolve(encoder.encode(json));
+					return Promise.resolve(
+						textEncoder.encode(
+							JSON.stringify({
+								config: {
+									'vendor-dir': 'newvendor',
+								},
+							})
+						)
+					);
 			}
 
 			throw new Error('Invalid path: ' + uri.path);
@@ -142,11 +146,12 @@ describe('Configuration', () => {
 		jest.mocked(workspace.fs.stat).mockImplementation((uri) => {
 			switch (uri.path) {
 				case 'test/newvendor/bin/phpcs.bat':
-				case 'test/newvendor/bin/phpcs':
+				case 'test/newvendor/bin/phpcs': {
 					const ret = new Uri();
 					ret.path = 'test';
 					ret.fsPath = 'test';
 					return Promise.resolve(ret);
+				}
 			}
 
 			throw new Error('Invalid path: ' + uri.path);
@@ -186,7 +191,10 @@ describe('Configuration', () => {
 		);
 		expect(result).toMatchObject({
 			workingDirectory: 'test',
-			executable: process.platform === 'win32' ? 'test/newvendor/bin/phpcs.bat' : 'test/newvendor/bin/phpcs',
+			executable:
+				process.platform === 'win32'
+					? 'test/newvendor/bin/phpcs.bat'
+					: 'test/newvendor/bin/phpcs',
 			exclude: [],
 			standard: StandardType.Disabled,
 		});
@@ -219,13 +227,15 @@ describe('Configuration', () => {
 				case 'test/file/composer.json':
 					return Promise.reject(new FileSystemError(uri));
 				case 'test/composer.json':
-					const json = JSON.stringify({
-						config: {
-							'vendor-dir': 'newvendor',
-						},
-					});
-					const encoder = new TextEncoder();
-					return Promise.resolve(encoder.encode(json));
+					return Promise.resolve(
+						textEncoder.encode(
+							JSON.stringify({
+								config: {
+									'vendor-dir': 'newvendor',
+								},
+							})
+						)
+					);
 			}
 
 			throw new Error('Invalid path: ' + uri.path);
@@ -234,11 +244,12 @@ describe('Configuration', () => {
 		jest.mocked(workspace.fs.stat).mockImplementation((uri) => {
 			switch (uri.path) {
 				case 'test/newvendor/bin/phpcs.bat':
-				case 'test/newvendor/bin/phpcs':
+				case 'test/newvendor/bin/phpcs': {
 					const ret = new Uri();
 					ret.path = 'test';
 					ret.fsPath = 'test';
 					return Promise.resolve(ret);
+				}
 			}
 
 			throw new Error('Invalid path: ' + uri.path);

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -235,13 +235,13 @@ export class Configuration {
 		let executableSetting: string;
 		switch (process.platform) {
 			case 'win32':
-				executableSetting = 'executable.windows';
+				executableSetting = 'exec.windows';
 				break;
 			case 'darwin':
-				executableSetting = 'executable.osx';
+				executableSetting = 'exec.osx';
 				break;
 			default:
-				executableSetting = 'executable.linux';
+				executableSetting = 'exec.linux';
 				break;
 		}
 		const executable = config.get<string>(executableSetting);


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

This pull request adds explicit Windows support to the extension. Previously only Linux and OSX would work natively, and so on Windows, your only option was to use WSL.

### How to test the changes in this Pull Request:

**Note: These tests must be done natively in Windows. You cannot validate them with a remote development environment from within WSL since that already worked.**

1. Ensure that diagnostics are generated on Windows.
2. Ensure that code actions execute correctly on Windows.
3. Ensure that full and selection document formatting works on Windows.
