### PR TITLE
Stabilize Working Directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `Automatic` option for `phpCodeSniffer.standard` that searches for a coding standard file
 (`phpcs.xml`, `.phpcs.xml`, `phpcs.dist.xml`, `.phpcs.dist.xml`). The search begins in the
-document's folder and traverses through parent directories until it reaches the workspace root.
+document's folder and traverses through parent folders until it reaches the workspace root.
 - `phpCodeSniffer.exec.linux`, `phpCodeSniffer.exec.osx`, and `phpCodeSniffer.exec.windows` options
 for platform-specific executables.
 - Support for execution on Windows without the use of WSL.
+
+### Changed
+- Even if `phpCodeSniffer.autoExecutable` is enabled, the working directory given to PHPCS should always be the workspace root.
+
+### Deprecated
+- `phpCodeSniffer.executable` has been deprecated in favor of platform-specific executable options.
 
 ### Fixed
 - Gracefully handle errors caused by an invalid PHPCS executable setting.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Allow PHPCS to decide what standard should apply to the document. It will either
 
 #### `Automatic`
 
-When selected, this option will cause the extension to search for an applicable coding standard file (`.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist`, `phpcs.xml.dist`). The extension starts in the document's directory and traverses through parent directories until it reaches the workspace root. If the extension fails to find a file it will do nothing and output an error.
+When selected, this option will cause the extension to search for an applicable coding standard file (`.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist`, `phpcs.xml.dist`). The extension starts in the document's folder and traverses through parent directories until it reaches the workspace root. If the extension fails to find a file it will do nothing and output an error.
 
 #### `Custom`
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "properties": {
         "phpCodeSniffer.autoExecutable": {
           "type": "boolean",
-          "markdownDescription": "Attempts to find `bin/phpcs` in the file directory and parent directories' vendor directory before falling back to the platform-specific executable.",
+          "markdownDescription": "Attempts to find `bin/phpcs` in the file folder and parent directories' vendor folder before falling back to the platform-specific executable.",
           "default": false,
           "scope": "resource"
         },
@@ -107,7 +107,7 @@
           "enumDescriptions": [
             "Disables the PHP_CodeSniffer extension's linting.",
             "Allows PHPCS to decide the coding standard.",
-            "Searches for a coding standard configuration file in the current document's directory and parent directories.",
+            "Searches for a coding standard configuration file in the current document's folder and parent directories.",
             "Uses the PEAR coding standard.",
             "Uses the MySource coding standard.",
             "Uses the Squiz coding standard.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ export function activate(context: ExtensionContext): void {
 	const workerPool = new WorkerPool(10);
 	const diagnosticUpdater = new DiagnosticUpdater(
 		logger,
+		workspaceLocator,
 		configuration,
 		workerPool,
 		linterStatus,
@@ -43,11 +44,13 @@ export function activate(context: ExtensionContext): void {
 	);
 	const codeActionEditResolver = new CodeActionEditResolver(
 		logger,
+		workspaceLocator,
 		configuration,
 		workerPool
 	);
 	const documentFormatter = new DocumentFormatter(
 		logger,
+		workspaceLocator,
 		configuration,
 		workerPool
 	);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { DiagnosticUpdater } from './services/diagnostic-updater';
 import { DocumentFormatter } from './services/document-formatter';
 import { Logger } from './services/logger';
 import { LinterStatus } from './services/linter-status';
+import { WorkspaceLocator } from './services/workspace-locator';
 
 export function activate(context: ExtensionContext): void {
 	// We will store all of the diagnostics and code actions
@@ -29,7 +30,8 @@ export function activate(context: ExtensionContext): void {
 	// Create all of our dependencies.
 	const logger = new Logger(window);
 	const linterStatus = new LinterStatus(window);
-	const configuration = new Configuration(workspace);
+	const workspaceLocator = new WorkspaceLocator(workspace);
+	const configuration = new Configuration(workspace, workspaceLocator);
 	const workerPool = new WorkerPool(10);
 	const diagnosticUpdater = new DiagnosticUpdater(
 		logger,

--- a/src/phpcs-report/__tests__/worker-integration.test.ts
+++ b/src/phpcs-report/__tests__/worker-integration.test.ts
@@ -51,7 +51,6 @@ describe('Worker/WorkerPool Integration', () => {
 				documentPath: 'Test.php',
 				documentContent: '<?php class Test {}',
 				options: {
-					workingDirectory: __dirname,
 					executable: phpcsPath,
 					standard: 'PSR12',
 				},
@@ -80,7 +79,6 @@ describe('Worker/WorkerPool Integration', () => {
 				documentPath: 'Test.php',
 				documentContent: '<?php class Test {}',
 				options: {
-					workingDirectory: __dirname,
 					executable: phpcsPath,
 					standard: 'PSR12',
 				},

--- a/src/phpcs-report/__tests__/worker-integration.test.ts
+++ b/src/phpcs-report/__tests__/worker-integration.test.ts
@@ -47,6 +47,7 @@ describe('Worker/WorkerPool Integration', () => {
 		const promise = pool.waitForAvailable('test').then((worker) => {
 			const request: Request<ReportType.Diagnostic> = {
 				type: ReportType.Diagnostic,
+				workingDirectory: __dirname,
 				documentPath: 'Test.php',
 				documentContent: '<?php class Test {}',
 				options: {
@@ -75,6 +76,7 @@ describe('Worker/WorkerPool Integration', () => {
 		const promise = pool.waitForAvailable('test').then((worker) => {
 			const request: Request<ReportType.Diagnostic> = {
 				type: ReportType.Diagnostic,
+				workingDirectory: __dirname,
 				documentPath: 'Test.php',
 				documentContent: '<?php class Test {}',
 				options: {

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -50,7 +50,6 @@ describe('Worker', () => {
 			documentPath: 'Test.php',
 			documentContent: '',
 			options: {
-				workingDirectory: __dirname,
 				executable: phpcsPath,
 				standard: 'PSR12',
 			},
@@ -73,7 +72,6 @@ describe('Worker', () => {
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
-				workingDirectory: __dirname,
 				executable: phpcsPath,
 				standard: 'PSR12',
 			},
@@ -98,7 +96,6 @@ describe('Worker', () => {
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
-				workingDirectory: __dirname,
 				executable: phpcsPath,
 				standard: 'PSR12',
 			},
@@ -139,7 +136,6 @@ describe('Worker', () => {
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
-				workingDirectory: __dirname,
 				executable: phpcsPath,
 				standard: 'PSR12',
 			},
@@ -162,7 +158,6 @@ describe('Worker', () => {
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
-				workingDirectory: __dirname,
 				executable: phpcsPath,
 				standard: 'PSR12',
 			},
@@ -189,7 +184,6 @@ describe('Worker', () => {
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
-				workingDirectory: __dirname,
 				executable: phpcsPath,
 				standard: 'PSR12',
 			},
@@ -211,7 +205,6 @@ describe('Worker', () => {
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
-				workingDirectory: __dirname,
 				// Since we use custom reports, adding `-s` for sources won't break anything.
 				executable: phpcsPath + ' -s',
 				standard: 'PSR12',

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -46,6 +46,7 @@ describe('Worker', () => {
 
 		const request: Request<ReportType.Diagnostic> = {
 			type: ReportType.Diagnostic,
+			workingDirectory: __dirname,
 			documentPath: 'Test.php',
 			documentContent: '',
 			options: {
@@ -68,6 +69,7 @@ describe('Worker', () => {
 
 		const request: Request<ReportType.Diagnostic> = {
 			type: ReportType.Diagnostic,
+			workingDirectory: __dirname,
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
@@ -92,6 +94,7 @@ describe('Worker', () => {
 
 		const request: Request<ReportType.CodeAction> = {
 			type: ReportType.CodeAction,
+			workingDirectory: __dirname,
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
@@ -132,6 +135,7 @@ describe('Worker', () => {
 
 		const request: Request<ReportType.Format> = {
 			type: ReportType.Format,
+			workingDirectory: __dirname,
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
@@ -154,6 +158,7 @@ describe('Worker', () => {
 
 		const request: Request<ReportType.Diagnostic> = {
 			type: ReportType.Diagnostic,
+			workingDirectory: __dirname,
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
@@ -180,6 +185,7 @@ describe('Worker', () => {
 
 		const request: Request<ReportType.Diagnostic> = {
 			type: ReportType.Diagnostic,
+			workingDirectory: __dirname,
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {
@@ -201,6 +207,7 @@ describe('Worker', () => {
 
 		const request: Request<ReportType.Diagnostic> = {
 			type: ReportType.Diagnostic,
+			workingDirectory: __dirname,
 			documentPath: 'Test.php',
 			documentContent: '<?php class Test {}',
 			options: {

--- a/src/phpcs-report/request.ts
+++ b/src/phpcs-report/request.ts
@@ -51,6 +51,11 @@ export interface Request<T extends ReportType> {
 	type: T;
 
 	/**
+	 * The working directory for the workspace that the report is being generated for.
+	 */
+	workingDirectory: string;
+
+	/**
 	 * The filesystem path for the document that the report is being generated for.
 	 */
 	documentPath: string;

--- a/src/phpcs-report/request.ts
+++ b/src/phpcs-report/request.ts
@@ -4,7 +4,6 @@ import { ReportType } from './response';
  * The request options for PHPCS.
  */
 export interface RequestOptions {
-	workingDirectory: string;
 	executable: string;
 	standard: string | null;
 }

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -205,6 +205,7 @@ export class Worker {
 
 		// Prepare the options for the PHPCS process.
 		const processOptions: SpawnOptionsWithoutStdio = {
+			cwd: request.workingDirectory,
 			env: {
 				...process.env,
 				// Pass the request data using environment vars.
@@ -215,11 +216,6 @@ export class Worker {
 			},
 			windowsHide: true,
 		};
-
-		// Give the working directory when requested.
-		if (request.options.workingDirectory) {
-			processOptions.cwd = request.options.workingDirectory;
-		}
 
 		// Make sure PHPCS knows to read from STDIN.
 		processArguments.push('-');

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -143,7 +143,7 @@ describe('Configuration', () => {
 			mockConfiguration as never
 		);
 
-		// We will traverse from the file directory up.
+		// We will traverse from the file folder up.
 		jest.mocked(workspace).fs.readFile.mockImplementation((uri) => {
 			switch (uri.path) {
 				case 'test/file/composer.json':
@@ -211,7 +211,7 @@ describe('Configuration', () => {
 			mockConfiguration as never
 		);
 
-		// We will never find the directory we are looking for
+		// We will never find the folder we are looking for
 		jest.mocked(workspace).fs.readFile.mockImplementation((uri) => {
 			return Promise.reject(new FileSystemError(uri));
 		});
@@ -334,7 +334,7 @@ describe('Configuration', () => {
 		});
 
 		describe('automatic', () => {
-			it('document directory', async () => {
+			it('document folder', async () => {
 				jest.mocked(workspace).fs.stat.mockImplementation((uri) => {
 					switch (uri.path) {
 						case 'test/file/phpcs.xml':
@@ -373,7 +373,7 @@ describe('Configuration', () => {
 				});
 			});
 
-			it('parent directory', async () => {
+			it('parent folder', async () => {
 				jest.mocked(workspace).fs.stat.mockImplementation((uri) => {
 					switch (uri.path) {
 						case 'test/file/phpcs.xml':

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -119,7 +119,6 @@ describe('Configuration', () => {
 			mockDocument
 		);
 		expect(result).toMatchObject({
-			workingDirectory: 'test',
 			executable: 'test.platform',
 			exclude: [/^(?:test\/\\{test|test-test}\/(?!\.)(?=.)[^/]*?\.php)$/],
 			standard: null,
@@ -185,7 +184,6 @@ describe('Configuration', () => {
 			mockDocument
 		);
 		expect(result).toMatchObject({
-			workingDirectory: 'test',
 			executable:
 				process.platform === 'win32'
 					? 'test/newvendor/bin/phpcs.bat'
@@ -225,7 +223,6 @@ describe('Configuration', () => {
 			mockDocument
 		);
 		expect(result).toMatchObject({
-			workingDirectory: 'test',
 			executable: 'test.platform',
 			exclude: [],
 			standard: null,
@@ -254,7 +251,6 @@ describe('Configuration', () => {
 				mockDocument
 			);
 			expect(result).toMatchObject({
-				workingDirectory: 'test',
 				executable: 'test.platform',
 				exclude: [],
 				standard: null,
@@ -280,7 +276,6 @@ describe('Configuration', () => {
 				mockDocument
 			);
 			expect(result).toMatchObject({
-				workingDirectory: 'test',
 				executable: 'test.platform',
 				exclude: [],
 				standard: '',
@@ -307,7 +302,6 @@ describe('Configuration', () => {
 				mockDocument
 			);
 			expect(result).toMatchObject({
-				workingDirectory: 'test',
 				executable: 'test.platform',
 				exclude: [],
 				standard: 'test-custom',
@@ -333,7 +327,6 @@ describe('Configuration', () => {
 				mockDocument
 			);
 			expect(result).toMatchObject({
-				workingDirectory: 'test',
 				executable: 'test.platform',
 				exclude: [],
 				standard: 'LITERAL',
@@ -374,7 +367,6 @@ describe('Configuration', () => {
 					mockDocument
 				);
 				expect(result).toMatchObject({
-					workingDirectory: 'test',
 					executable: 'test.platform',
 					exclude: [],
 					standard: 'test/file/phpcs.xml',
@@ -424,7 +416,6 @@ describe('Configuration', () => {
 					mockDocument
 				);
 				expect(result).toMatchObject({
-					workingDirectory: 'test',
 					executable: 'test.platform',
 					exclude: [],
 					standard: 'test/.phpcs.xml',
@@ -475,7 +466,6 @@ describe('Configuration', () => {
 				mockDocument
 			);
 			expect(result).toMatchObject({
-				workingDirectory: 'test',
 				executable: 'test.override',
 				exclude: [],
 				standard: null,
@@ -502,7 +492,6 @@ describe('Configuration', () => {
 				mockDocument
 			);
 			expect(result).toMatchObject({
-				workingDirectory: 'test',
 				executable: 'test.platform',
 				exclude: [
 					/^(?:test\/\\{test|test-test}\/(?!\.)(?=.)[^/]*?\.php)$/,

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -89,7 +89,9 @@ describe('Configuration', () => {
 		const workspaceUri = new Uri();
 		workspaceUri.path = 'test';
 		workspaceUri.fsPath = 'test';
-		jest.mocked(mockWorkspaceLocator).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
+		jest.mocked(
+			mockWorkspaceLocator
+		).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
 	});
 
 	afterEach(() => {
@@ -210,7 +212,7 @@ describe('Configuration', () => {
 		jest.mocked(workspace).getConfiguration.mockReturnValue(
 			mockConfiguration as never
 		);
-		
+
 		// We will never find the directory we are looking for
 		jest.mocked(workspace).fs.readFile.mockImplementation((uri) => {
 			return Promise.reject(new FileSystemError(uri));

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -96,9 +96,10 @@ describe('DiagnosticUpdater', () => {
 		const workspaceUri = new Uri();
 		workspaceUri.path = 'test-dir';
 		workspaceUri.fsPath = 'test-dir';
-		jest.mocked(mockWorkspaceLocator).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
+		jest.mocked(
+			mockWorkspaceLocator
+		).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
 		jest.mocked(mockConfiguration).get.mockResolvedValue({
-			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',
 			exclude: [],
 			lintAction: LintAction.Change,
@@ -107,8 +108,8 @@ describe('DiagnosticUpdater', () => {
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
 				type: ReportType.Diagnostic,
+				workingDirectory: 'test-dir',
 				options: {
-					workingDirectory: 'test-dir',
 					executable: 'phpcs-test',
 					standard: 'PSR12',
 				},
@@ -157,9 +158,10 @@ describe('DiagnosticUpdater', () => {
 		const workspaceUri = new Uri();
 		workspaceUri.path = 'test-dir';
 		workspaceUri.fsPath = 'test-dir';
-		jest.mocked(mockWorkspaceLocator).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
+		jest.mocked(
+			mockWorkspaceLocator
+		).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
 		jest.mocked(mockConfiguration).get.mockResolvedValue({
-			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',
 			exclude: [],
 			lintAction: LintAction.Change,
@@ -168,8 +170,8 @@ describe('DiagnosticUpdater', () => {
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
 				type: ReportType.Diagnostic,
+				workingDirectory: 'test-dir',
 				options: {
-					workingDirectory: 'test-dir',
 					executable: 'phpcs-test',
 					standard: 'PSR12',
 				},
@@ -192,7 +194,6 @@ describe('DiagnosticUpdater', () => {
 		document.fileName = 'test-document';
 
 		jest.mocked(mockConfiguration).get.mockResolvedValue({
-			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',
 			exclude: [new RegExp('.*/file/.*')],
 			lintAction: LintAction.Change,
@@ -207,7 +208,6 @@ describe('DiagnosticUpdater', () => {
 		document.fileName = 'test-document';
 
 		jest.mocked(mockConfiguration).get.mockResolvedValue({
-			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',
 			exclude: [],
 			lintAction: LintAction.Save,

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -15,6 +15,7 @@ import { DiagnosticUpdater } from '../diagnostic-updater';
 import {
 	MockDiagnosticCollection,
 	MockTextDocument,
+	Uri,
 } from '../../__mocks__/vscode';
 import { PHPCSError, Worker } from '../../phpcs-report/worker';
 import { ReportType, Response } from '../../phpcs-report/response';
@@ -72,6 +73,7 @@ describe('DiagnosticUpdater', () => {
 
 		diagnosticUpdater = new DiagnosticUpdater(
 			mockLogger,
+			mockWorkspaceLocator,
 			mockConfiguration,
 			mockWorkerPool,
 			mockLinterStatus,
@@ -91,6 +93,10 @@ describe('DiagnosticUpdater', () => {
 				return Promise.resolve(mockWorker);
 			}
 		);
+		const workspaceUri = new Uri();
+		workspaceUri.path = 'test-dir';
+		workspaceUri.fsPath = 'test-dir';
+		jest.mocked(mockWorkspaceLocator).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
 		jest.mocked(mockConfiguration).get.mockResolvedValue({
 			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',
@@ -148,6 +154,10 @@ describe('DiagnosticUpdater', () => {
 				return Promise.resolve(mockWorker);
 			}
 		);
+		const workspaceUri = new Uri();
+		workspaceUri.path = 'test-dir';
+		workspaceUri.fsPath = 'test-dir';
+		jest.mocked(mockWorkspaceLocator).getWorkspaceFolderOrDefault.mockReturnValue(workspaceUri);
 		jest.mocked(mockConfiguration).get.mockResolvedValue({
 			workingDirectory: 'test-dir',
 			executable: 'phpcs-test',

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -20,9 +20,11 @@ import { PHPCSError, Worker } from '../../phpcs-report/worker';
 import { ReportType, Response } from '../../phpcs-report/response';
 import { Logger } from '../../services/logger';
 import { LinterStatus } from '../linter-status';
+import { WorkspaceLocator } from '../workspace-locator';
 
 jest.mock('../logger');
 jest.mock('../linter-status');
+jest.mock('../workspace-locator');
 jest.mock('../configuration');
 jest.mock('../../phpcs-report/worker');
 jest.mock('../../phpcs-report/worker-pool');
@@ -42,6 +44,7 @@ jest.mock('../../types', () => {
 
 describe('DiagnosticUpdater', () => {
 	let mockLogger: Logger;
+	let mockWorkspaceLocator: WorkspaceLocator;
 	let mockConfiguration: Configuration;
 	let mockWorkerPool: WorkerPool;
 	let mockLinterStatus: LinterStatus;
@@ -60,7 +63,8 @@ describe('DiagnosticUpdater', () => {
 		);
 
 		mockLogger = new Logger(window);
-		mockConfiguration = new Configuration(workspace);
+		mockWorkspaceLocator = new WorkspaceLocator(workspace);
+		mockConfiguration = new Configuration(workspace, mockWorkspaceLocator);
 		mockWorkerPool = new WorkerPool(1);
 		mockLinterStatus = new LinterStatus(window);
 		mockDiagnosticCollection = new MockDiagnosticCollection();

--- a/src/services/__tests__/workspace-locator.spec.ts
+++ b/src/services/__tests__/workspace-locator.spec.ts
@@ -1,0 +1,67 @@
+import { workspace } from 'vscode';
+import { Uri } from '../../__mocks__/vscode';
+import { WorkspaceLocator } from '../workspace-locator';
+
+describe('WorkspaceLocator', () => {
+	let workspaceLocator: WorkspaceLocator;
+
+	beforeEach(() => {
+		workspaceLocator = new WorkspaceLocator(workspace);
+	});
+
+	afterEach(() => {
+		jest.mocked(workspace).getWorkspaceFolder.mockReset();
+
+        // @ts-ignore
+        workspace.workspaceFolders = undefined;
+	});
+
+	it('should find workspace folder for uri', () => {
+		const workspaceUri = new Uri();
+		workspaceUri.path = 'test';
+		workspaceUri.fsPath = 'test';
+		jest.mocked(workspace).getWorkspaceFolder.mockReturnValue({
+			uri: workspaceUri,
+		} as never);
+
+		const testUri = new Uri();
+		testUri.path = 'test/test.php';
+		testUri.fsPath = 'test/test.php';
+
+		const folder = workspaceLocator.getWorkspaceFolderOrDefault(testUri);
+
+		expect(folder.fsPath).toEqual('test');
+	});
+
+	it('should default to first workspace when uri has no workspace folder', () => {
+		const workspaceUri = new Uri();
+		workspaceUri.path = 'test/default';
+		workspaceUri.fsPath = 'test/default';
+        // @ts-ignore
+        workspace.workspaceFolders = [
+			{
+				uri: workspaceUri,
+			} as never,
+		];
+
+		const testUri = new Uri();
+		testUri.path = 'test/test.php';
+		testUri.fsPath = 'test/test.php';
+
+		const folder = workspaceLocator.getWorkspaceFolderOrDefault(testUri);
+
+		expect(folder.fsPath).toEqual('test/default');
+	});
+
+	it('should fall back to folder containing uri when there are no workspaces', () => {
+		jest.mocked(workspace).getWorkspaceFolder.mockReturnValue(undefined);
+
+		const testUri = new Uri();
+		testUri.path = 'test/fallback/test.php';
+		testUri.fsPath = 'test/fallback/test.php';
+
+		const folder = workspaceLocator.getWorkspaceFolderOrDefault(testUri);
+
+		expect(folder.fsPath).toEqual('test/fallback');
+	});
+});

--- a/src/services/__tests__/workspace-locator.spec.ts
+++ b/src/services/__tests__/workspace-locator.spec.ts
@@ -12,8 +12,8 @@ describe('WorkspaceLocator', () => {
 	afterEach(() => {
 		jest.mocked(workspace).getWorkspaceFolder.mockReset();
 
-        // @ts-ignore
-        workspace.workspaceFolders = undefined;
+		// @ts-ignore
+		workspace.workspaceFolders = undefined;
 	});
 
 	it('should find workspace folder for uri', () => {
@@ -37,8 +37,8 @@ describe('WorkspaceLocator', () => {
 		const workspaceUri = new Uri();
 		workspaceUri.path = 'test/default';
 		workspaceUri.fsPath = 'test/default';
-        // @ts-ignore
-        workspace.workspaceFolders = [
+		// @ts-ignore
+		workspace.workspaceFolders = [
 			{
 				uri: workspaceUri,
 			} as never,

--- a/src/services/code-action-edit-resolver.ts
+++ b/src/services/code-action-edit-resolver.ts
@@ -57,11 +57,16 @@ export class CodeActionEditResolver extends WorkerService {
 				);
 			})
 			.then(async (worker) => {
+				const workspaceUri =
+					this.workspaceLocator.getWorkspaceFolderOrDefault(
+						document.uri
+					);
 				const config = await this.configuration.get(document);
 
 				// Use the worker to make a request for a code action report.
 				const request: Request<ReportType.CodeAction> = {
 					type: ReportType.CodeAction,
+					workingDirectory: workspaceUri.fsPath,
 					documentPath: document.uri.fsPath,
 					documentContent: document.getText(),
 					options: {

--- a/src/services/code-action-edit-resolver.ts
+++ b/src/services/code-action-edit-resolver.ts
@@ -70,7 +70,6 @@ export class CodeActionEditResolver extends WorkerService {
 					documentPath: document.uri.fsPath,
 					documentContent: document.getText(),
 					options: {
-						workingDirectory: config.workingDirectory,
 						executable: config.executable,
 						standard: config.standard,
 					},

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -141,9 +141,12 @@ export class Configuration {
 	 * @param {workspace} workspace The VS Code workspace our configuration is in.
 	 * @param {WorkspaceLocator} workspaceLocator The locator we will use to look at the workspace.
 	 */
-	public constructor(workspace: typeof vsCodeWorkspace, workspaceLocator: WorkspaceLocator) {
+	public constructor(
+		workspace: typeof vsCodeWorkspace,
+		workspaceLocator: WorkspaceLocator
+	) {
 		this.workspace = workspace;
-		this.workspaceLocator = workspaceLocator
+		this.workspaceLocator = workspaceLocator;
 		this.cache = new UriMap();
 		this.textDecoder = new TextDecoder();
 	}
@@ -362,7 +365,8 @@ export class Configuration {
 		}
 
 		// We are only going to traverse as high as the workspace folder.
-		const workspaceFolder = this.workspaceLocator.getWorkspaceFolderOrDefault(document.uri);
+		const workspaceFolder =
+			this.workspaceLocator.getWorkspaceFolderOrDefault(document.uri);
 
 		const parsed = await this.traverseWorkspaceFolders(
 			document.uri,
@@ -390,7 +394,8 @@ export class Configuration {
 		cancellationToken?: CancellationToken
 	): Promise<ParamsFromFilesystem> {
 		// The workspace folder for the document is our default working directory.
-		const workspaceFolder = this.workspaceLocator.getWorkspaceFolderOrDefault(document.uri);
+		const workspaceFolder =
+			this.workspaceLocator.getWorkspaceFolderOrDefault(document.uri);
 
 		// Prepare the parameters that come from the filesystem.
 		const fsParams: ParamsFromFilesystem = {

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -47,14 +47,6 @@ export enum LintAction {
 }
 
 /**
- * An interface describing the path to an executable.
- */
-interface ExecutablePath {
-	workingDirectory: string;
-	executable: string;
-}
-
-/**
  * An interface describing the configuration parameters we can read from the filesystem.
  */
 interface ParamsFromFilesystem {
@@ -407,8 +399,7 @@ export class Configuration {
 			);
 
 			if (executable !== false) {
-				fsParams.workingDirectory = executable.workingDirectory;
-				fsParams.executable = executable.executable;
+				fsParams.executable = executable;
 			}
 		}
 
@@ -530,9 +521,7 @@ export class Configuration {
 	 *
 	 * @param {Uri} folder The folder we're checking for an executable in.
 	 */
-	private async findExecutableInFolder(
-		folder: Uri
-	): Promise<ExecutablePath | false> {
+	private async findExecutableInFolder(folder: Uri): Promise<string | false> {
 		try {
 			// We should be aware of custom vendor folders so that
 			// we can find the executable in the correct location.
@@ -565,10 +554,7 @@ export class Configuration {
 			await this.workspace.fs.stat(phpcsPath);
 
 			// The lack of an error indicates that the file exists.
-			return {
-				workingDirectory: folder.fsPath,
-				executable: phpcsPath.fsPath,
-			};
+			return phpcsPath.fsPath;
 		} catch (e) {
 			// Only errors from the filesystem are relevant.
 			if (!(e instanceof FileSystemError)) {

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -159,8 +159,6 @@ export class DiagnosticUpdater extends WorkerService {
 							documentPath: document.uri.fsPath,
 							documentContent: document.getText(),
 							options: {
-								workingDirectory:
-									configuration.workingDirectory,
 								executable: configuration.executable,
 								standard: configuration.standard,
 							},

--- a/src/services/document-formatter.ts
+++ b/src/services/document-formatter.ts
@@ -46,6 +46,10 @@ export class DocumentFormatter extends WorkerService {
 				);
 			})
 			.then(async (worker) => {
+				const workspaceUri =
+					this.workspaceLocator.getWorkspaceFolderOrDefault(
+						document.uri
+					);
 				const config = await this.configuration.get(document);
 
 				const data: FormatRequest = {};
@@ -64,6 +68,7 @@ export class DocumentFormatter extends WorkerService {
 				// Use the worker to make a request for a format report.
 				const request: Request<ReportType.Format> = {
 					type: ReportType.Format,
+					workingDirectory: workspaceUri.fsPath,
 					documentPath: document.uri.fsPath,
 					documentContent: document.getText(),
 					options: {

--- a/src/services/document-formatter.ts
+++ b/src/services/document-formatter.ts
@@ -72,7 +72,6 @@ export class DocumentFormatter extends WorkerService {
 					documentPath: document.uri.fsPath,
 					documentContent: document.getText(),
 					options: {
-						workingDirectory: config.workingDirectory,
 						executable: config.executable,
 						standard: config.standard,
 					},

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -8,6 +8,7 @@ import { Logger } from './logger';
 import { Configuration } from './configuration';
 import { WorkerPool } from '../phpcs-report/worker-pool';
 import { UriMap } from '../common/uri-map';
+import { WorkspaceLocator } from './workspace-locator';
 
 /**
  * A base class for all of the updates that interact with PHPCS.
@@ -17,6 +18,11 @@ export abstract class WorkerService implements Disposable {
 	 * The logger to use.
 	 */
 	protected readonly logger: Logger;
+
+	/**
+	 * The workspace locator.
+	 */
+	protected readonly workspaceLocator: WorkspaceLocator;
 
 	/**
 	 * The configuration object.
@@ -37,15 +43,18 @@ export abstract class WorkerService implements Disposable {
 	 * Constructor.
 	 *
 	 * @param {Logger} logger The logger to use.
+	 * @param {WorkspaceLocator} workspaceLocator The workspace locator to use.
 	 * @param {Configuration} configuration The configuration object to use.
 	 * @param {WorkerPool} workerPool The worker pool to use.
 	 */
 	public constructor(
 		logger: Logger,
+		workspaceLocator: WorkspaceLocator,
 		configuration: Configuration,
 		workerPool: WorkerPool
 	) {
 		this.logger = logger;
+		this.workspaceLocator = workspaceLocator;
 		this.configuration = configuration;
 		this.workerPool = workerPool;
 		this.cancellationTokenSourceMap = new UriMap();

--- a/src/services/workspace-locator.ts
+++ b/src/services/workspace-locator.ts
@@ -1,0 +1,40 @@
+import { Uri, workspace as vsCodeWorkspace } from 'vscode';
+
+export class WorkspaceLocator {
+	/**
+	 * The workspace we will locate things in.
+	 */
+	private readonly workspace: typeof vsCodeWorkspace;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param {workspace} workspace The workspace we are handling.
+	 */
+	public constructor(workspace: typeof vsCodeWorkspace) {
+		this.workspace = workspace;
+	}
+
+	/**
+	 * Fetches the workspace folder of a uri or the folder immediately enclosing it.
+	 *
+	 * @param {Uri} uri The uri to look for.
+	 */
+	public getWorkspaceFolderOrDefault(uri: Uri): Uri {
+		const folder = this.workspace.getWorkspaceFolder(uri);
+		if (folder) {
+			return folder.uri;
+		}
+
+		// Default to the first workspace when the uri is not associated with one.
+		if (
+			this.workspace.workspaceFolders &&
+			this.workspace.workspaceFolders.length > 0
+		) {
+			return this.workspace.workspaceFolders[0].uri;
+		}
+
+		// When we can't infer a path just use the folder of the uri.
+		return Uri.joinPath(uri, '..');
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

The working directory passed to `phpcs` would depends entirely on whether or not `phpCodeSniffer.autoExecutable` is enabled. When it is and it finds an executable, the working directory will be changed to the directory it found it in rather than the workspace root. This means that relative paths for `standardCustom` options are inconsistent without a clear explanation as to _why_.

Now that we have the `"Automatic"` standard option, there's no longer a reason to rely on the directory traversal provided by PHPCS. We should now set the workspace root as the working directory and never change it.

Note: This is a breaking change! Relative paths in `phpCodeSniffer.standard` may stop working, but, fixing them will be relatively easy.

Closes #60.

### How to test the changes in this Pull Request:

1. Extension should still work
