### PR TITLE
Fixed PHPCS Configuration Filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Display messages for configuration errors.
+
 ### Fixed
 - Detect `phpcs.xml.dist` and `.phpcs.xml.dist` configuration files.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Detect `phpcs.xml.dist` and `.phpcs.xml.dist` configuration files.
 
 ## [2.0.0] - 2023-04-13
 ### Added
 - `Automatic` option for `phpCodeSniffer.standard` that searches for a coding standard file
-(`phpcs.xml`, `.phpcs.xml`, `phpcs.dist.xml`, `.phpcs.dist.xml`). The search begins in the
+(`phpcs.xml`, `.phpcs.xml`, `phpcs.xml.dist`, `.phpcs.xml.dist`). The search begins in the
 document's folder and traverses through parent folders until it reaches the workspace root.
 - `phpCodeSniffer.exec.linux`, `phpCodeSniffer.exec.osx`, and `phpCodeSniffer.exec.windows` options
 for platform-specific executables.

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -378,8 +378,8 @@ describe('Configuration', () => {
 					switch (uri.path) {
 						case 'test/file/phpcs.xml':
 						case 'test/file/.phpcs.xml':
-						case 'test/file/phpcs.dist.xml':
-						case 'test/file/.phpcs.dist.xml':
+						case 'test/file/phpcs.xml.dist':
+						case 'test/file/.phpcs.xml.dist':
 							return Promise.reject(new FileSystemError(uri));
 
 						// Ignore the first filename to also test the other possible filenames.

--- a/src/services/code-action-edit-resolver.ts
+++ b/src/services/code-action-edit-resolver.ts
@@ -4,6 +4,7 @@ import { Request } from '../phpcs-report/request';
 import { ReportType } from '../phpcs-report/response';
 import { WorkerService } from './worker-service';
 import { PHPCSError } from '../phpcs-report/worker';
+import { ConfigurationError } from './configuration';
 
 /**
  * A class for resolving edits for code actions.
@@ -96,6 +97,12 @@ export class CodeActionEditResolver extends WorkerService {
 			.catch((e) => {
 				// Cancellation errors are acceptable as they mean we've just repeated the update before it completed.
 				if (e instanceof CancellationError) {
+					return codeAction;
+				}
+
+				// Configuration errors should be logged and presented to the user.
+				if (e instanceof ConfigurationError) {
+					this.logger.error(e);
 					return codeAction;
 				}
 

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -10,6 +10,7 @@ import {
 } from 'vscode';
 import { UriMap } from '../common/uri-map';
 import { WorkspaceLocator } from './workspace-locator';
+import { Logger } from './logger';
 
 /**
  * An enum describing the special parsing values in the `phpCodeSniffer.standard` configuration.
@@ -94,6 +95,34 @@ export interface DocumentConfiguration {
  * The type for the callback used when traversing workspace folders.
  */
 type FolderTraversalCallback<T> = (folderUri: Uri) => Promise<T | false>;
+
+/**
+ * A custom error type for those that come from PHPCS.
+ */
+export class ConfigurationError extends Error {
+	/**
+	 * The configuration key the error is for.
+	 */
+	public readonly configurationKey: string;
+
+	/**
+	 * The error message for the configuration key.
+	 */
+	public readonly errorMessage: string;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param {string} configurationKey The configuration key the error is for.
+	 * @param {string} message The message for the error.
+	 */
+	public constructor(configurationKey: string, message: string) {
+		super('Configuration "phpCodeSniffer.' + configurationKey + '" Error: ' + message);
+
+		this.configurationKey = configurationKey;
+		this.errorMessage = message;
+	}
+}
 
 /**
  * The valid filenames we look for when automatically searching for coding standards.
@@ -212,13 +241,17 @@ export class Configuration {
 			document
 		);
 		if (!config) {
-			throw new Error('The extension has no configuration.');
+			throw new ConfigurationError(
+				'phpCodeSniffer',
+				'The extension has no configuration.'
+			);
 		}
 
 		const autoExecutable = config.get<boolean>('autoExecutable');
 		if (autoExecutable === undefined) {
-			throw new Error(
-				'The extension has an invalid `phpCodeSniffer.autoExecutable` configuration.'
+			throw new ConfigurationError(
+				'autoExecutable',
+				'Value must be a boolean.'
 			);
 		}
 
@@ -237,10 +270,9 @@ export class Configuration {
 		}
 		const platformExecutable = config.get<string>(executableSetting);
 		if (platformExecutable === undefined) {
-			throw new Error(
-				'The extension has an invalid `' +
-					executableSetting +
-					'` configuration.'
+			throw new ConfigurationError(
+				executableSetting,
+				'Value must be a string.'
 			);
 		}
 
@@ -250,8 +282,9 @@ export class Configuration {
 
 		const excludePatterns = config.get<string[]>('exclude');
 		if (!Array.isArray(excludePatterns)) {
-			throw new Error(
-				'The extension has an invalid `phpCodeSniffer.exclude` configuration.'
+			throw new ConfigurationError(
+				'exclude',
+				'Value must be an array.'
 			);
 		}
 
@@ -273,8 +306,9 @@ export class Configuration {
 		);
 		if (deprecatedIgnorePatterns) {
 			if (!Array.isArray(deprecatedIgnorePatterns)) {
-				throw new Error(
-					'The extension has an invalid `phpCodeSniffer.ignorePatterns` configuration.'
+				throw new ConfigurationError(
+					'ignorePatterns',
+					'Value must be an array'
 				);
 			}
 
@@ -283,8 +317,9 @@ export class Configuration {
 
 		const lintAction = config.get<LintAction>('lintAction');
 		if (lintAction === undefined) {
-			throw new Error(
-				'The extension has an invalid `phpCodeSniffer.lintAction` configuration.'
+			throw new ConfigurationError(
+				'lintAction',
+				'Value must be a valid lint action.'
 			);
 		}
 
@@ -294,8 +329,9 @@ export class Configuration {
 			'standard'
 		);
 		if (rawStandard === undefined) {
-			throw new Error(
-				'The extension has an invalid `phpCodeSniffer.standard` configuration.'
+			throw new ConfigurationError(
+				'standard',
+				'Value must be a valid standard option.'
 			);
 		}
 		const standard = await this.parseStandard(
@@ -341,8 +377,9 @@ export class Configuration {
 
 			case SpecialStandardOptions.Custom:
 				if (!customStandard) {
-					throw new Error(
-						'The extension has an empty `phpCodeSniffer.standardCustom` configuration.'
+					throw new ConfigurationError(
+						'customStandard',
+						'Must be a string when using a custom standard.'
 					);
 				}
 
@@ -363,8 +400,9 @@ export class Configuration {
 			cancellationToken
 		);
 		if (parsed === false) {
-			throw new Error(
-				'The extension failed to automatically find a PHPCS configuration file.'
+			throw new ConfigurationError(
+				'standard',
+				'Failed to locate a PHPCS configuration file for "' + document.uri.fsPath + '".'
 			);
 		}
 

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -10,7 +10,6 @@ import {
 } from 'vscode';
 import { UriMap } from '../common/uri-map';
 import { WorkspaceLocator } from './workspace-locator';
-import { Logger } from './logger';
 
 /**
  * An enum describing the special parsing values in the `phpCodeSniffer.standard` configuration.

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -117,7 +117,12 @@ export class ConfigurationError extends Error {
 	 * @param {string} message The message for the error.
 	 */
 	public constructor(configurationKey: string, message: string) {
-		super('Configuration "phpCodeSniffer.' + configurationKey + '" Error: ' + message);
+		super(
+			'Configuration "phpCodeSniffer.' +
+				configurationKey +
+				'" Error: ' +
+				message
+		);
 
 		this.configurationKey = configurationKey;
 		this.errorMessage = message;
@@ -282,10 +287,7 @@ export class Configuration {
 
 		const excludePatterns = config.get<string[]>('exclude');
 		if (!Array.isArray(excludePatterns)) {
-			throw new ConfigurationError(
-				'exclude',
-				'Value must be an array.'
-			);
+			throw new ConfigurationError('exclude', 'Value must be an array.');
 		}
 
 		// Parse the glob patterns into a format we can use.
@@ -402,7 +404,9 @@ export class Configuration {
 		if (parsed === false) {
 			throw new ConfigurationError(
 				'standard',
-				'Failed to locate a PHPCS configuration file for "' + document.uri.fsPath + '".'
+				'Failed to locate a PHPCS configuration file for "' +
+					document.uri.fsPath +
+					'".'
 			);
 		}
 

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -101,8 +101,8 @@ type FolderTraversalCallback<T> = (folderUri: Uri) => Promise<T | false>;
 export const AutomaticCodingStandardFilenames = [
 	'phpcs.xml',
 	'.phpcs.xml',
-	'phpcs.dist.xml',
-	'.phpcs.dist.xml',
+	'phpcs.xml.dist',
+	'.phpcs.xml.dist',
 ];
 
 /**
@@ -363,7 +363,9 @@ export class Configuration {
 			cancellationToken
 		);
 		if (parsed === false) {
-			return null;
+			throw new Error(
+				'The extension failed to automatically find a PHPCS configuration file.'
+			);
 		}
 
 		return parsed;

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -7,7 +7,7 @@ import {
 } from 'vscode';
 import { CodeAction, CodeActionCollection } from '../types';
 import { IgnoreLineCommand } from '../commands/ignore-line-command';
-import { Configuration, LintAction } from './configuration';
+import { Configuration, ConfigurationError, LintAction } from './configuration';
 import { Logger } from './logger';
 import { Request } from '../phpcs-report/request';
 import { ReportType } from '../phpcs-report/response';
@@ -206,6 +206,12 @@ export class DiagnosticUpdater extends WorkerService {
 
 				// Let the status know we're not linting the document anymore.
 				this.linterStatus.stop(document.uri);
+
+				// Configuration errors should be logged and presented to the user.
+				if (e instanceof ConfigurationError) {
+					this.logger.error(e);
+					return;
+				}
 
 				// Updates can be prevented in expected ways, so this error is acceptable.
 				if (e instanceof UpdatePreventedError) {

--- a/src/services/document-formatter.ts
+++ b/src/services/document-formatter.ts
@@ -9,6 +9,7 @@ import { FormatRequest, Request } from '../phpcs-report/request';
 import { ReportType } from '../phpcs-report/response';
 import { PHPCSError } from '../phpcs-report/worker';
 import { WorkerService } from './worker-service';
+import { ConfigurationError } from './configuration';
 
 /**
  * A class for formatting documents and document ranges.
@@ -99,6 +100,12 @@ export class DocumentFormatter extends WorkerService {
 			.catch((e) => {
 				// Cancellation errors are acceptable as they mean we've just repeated the update before it completed.
 				if (e instanceof CancellationError) {
+					return [];
+				}
+
+				// Configuration errors should be logged and presented to the user.
+				if (e instanceof ConfigurationError) {
+					this.logger.error(e);
 					return [];
 				}
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,5 +1,6 @@
 import { Disposable, OutputChannel, window as vsCodeWindow } from 'vscode';
 import { PHPCSError } from '../phpcs-report/worker';
+import { ConfigurationError } from './configuration';
 
 /**
  * A logger for presenting errors to the user.
@@ -38,6 +39,14 @@ export class Logger implements Disposable {
 	 * @param {Error} error The error to log.
 	 */
 	public error(error: Error): void {
+		// Users should be informed of errors with their configuration.
+		if (error instanceof ConfigurationError) {
+			this.window.showErrorMessage(error.message);
+			this.outputChannel.show(true);
+			this.writeMessage(error.message);
+			return;
+		}
+
 		// Users should be informed of PHPCS errors.
 		if (error instanceof PHPCSError) {
 			this.window.showErrorMessage(error.message);


### PR DESCRIPTION
I made a mistake and the wrong files were listed!

### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Apparently I messed up when adding the filenames for the default PHPCS configuration files. This pull request fixes that mistake. I've also added appropriate errors for configuration errors.

Closes https://github.com/ObliviousHarmony/vscode-php-codesniffer/issues/55.

### How to test the changes in this Pull Request:

1. Make sure `phpcs.xml.dist` is picked up automatically.
