### PR TITLE
Fixed Windows Traversal Root Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Detection of filesystem root when traversing paths on Windows.
 
 ## [2.0.0] - 2023-04-13
 ### Added

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -39,6 +39,10 @@ Uri.joinPath = jest
 			uriSegments.push(seg);
 		}
 
+		if (uriSegments.length <= 0) {
+			uriSegments.push(process.platform === 'win32' ? 'c:/' : '/');
+		}
+
 		const path = uriSegments.join('/');
 
 		const created = {

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -431,9 +431,8 @@ export class Configuration {
 				return false;
 		}
 
-		// Only traverse as far as the workspace folder. We don't
-		// want to accidentally check folders outside of it.
-		while (folder.path !== '/') {
+		// When we reach the filesystem root we have no reason to keep searching.
+		while (!folder.path.match(/^(?:[a-z]:)?\/$/i)) {
 			// When the request is cancelled, we don't want to keep looking.
 			if (cancellationToken?.isCancellationRequested) {
 				throw new CancellationError();


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

This pull request fixes a theoretical bug wherein the configuration path traversal will never break the loop.

### How to test the changes in this Pull Request:

N/A
