### PR TITLE
Clear Diagnostics On Unacceptable Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Clear diagnostics when exceptions are thrown while updating them.
+
 ## [2.1.0] - 2023-04-19
 ### Added
 - Display messages for configuration errors.

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -207,14 +207,18 @@ export class DiagnosticUpdater extends WorkerService {
 				// Let the status know we're not linting the document anymore.
 				this.linterStatus.stop(document.uri);
 
-				// Configuration errors should be logged and presented to the user.
-				if (e instanceof ConfigurationError) {
-					this.logger.error(e);
+				// Updates can be prevented in expected ways, so this error is acceptable.
+				if (e instanceof UpdatePreventedError) {
 					return;
 				}
 
-				// Updates can be prevented in expected ways, so this error is acceptable.
-				if (e instanceof UpdatePreventedError) {
+				// When an unacceptable error is thrown we need to clear the document that way
+				// diagnostic information that is not valid is not left behind.
+				this.clearDocument(document);
+
+				// Configuration errors should be logged and presented to the user.
+				if (e instanceof ConfigurationError) {
+					this.logger.error(e);
 					return;
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

We should be clearing diagnostic information when we throw
exceptions that we did not accept. This prevents some
diagnostics to be left behind when they shouldn't be.

Closes #71.

### How to test the changes in this Pull Request:

1. Open a project with a working PHPCS extension configuration.
2. Make sure that there are visible errors in a document.
3. Break the configuration, such as by turning off autoExecutable and entering an invalid executable.
