### PR TITLE
Clear Diagnostics on Configuration Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Clear diagnostics on configuration changes.
+
 ## [2.1.0] - 2023-04-19
 ### Added
 - Display messages for configuration errors.

--- a/src/listeners/workspace-listener.ts
+++ b/src/listeners/workspace-listener.ts
@@ -293,6 +293,9 @@ export class WorkspaceListener implements Disposable {
 			// Don't allow for overlapping requests.
 			this.diagnosticUpdater.cancel(document);
 
+			// Since the output from the worker may have changed we should clear the potentially invalid diagnostics.
+			this.diagnosticUpdater.clearDocument(document);
+
 			// Update the diagnostics for the document.
 			this.diagnosticUpdater.update(document, LintAction.Force);
 		}
@@ -335,6 +338,9 @@ export class WorkspaceListener implements Disposable {
 			// Don't allow for overlapping requests.
 			this.diagnosticUpdater.cancel(document);
 
+			// Since the output from the worker may have changed we should clear the potentially invalid diagnostics.
+			this.diagnosticUpdater.clearDocument(document);
+
 			// Update the diagnostics for the document.
 			this.diagnosticUpdater.update(document, LintAction.Force);
 		}
@@ -357,6 +363,9 @@ export class WorkspaceListener implements Disposable {
 
 			// Don't allow for overlapping requests.
 			this.diagnosticUpdater.cancel(document);
+
+			// Since the output from the worker may have changed we should clear the potentially invalid diagnostics.
+			this.diagnosticUpdater.clearDocument(document);
 
 			// Update the diagnostics for the document.
 			this.diagnosticUpdater.update(document, LintAction.Force);


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Since the output might change as a result of configuration
adjustments we should clear the diagnostics. This keeps
us from displaying incorrect information.

Closes #72.

### How to test the changes in this Pull Request:

1. Open a project and create a diagnostic error.
2. Break the configuration and observe clearing.
3. Change the PHPCS file and observe clearing.
