### PR TITLE
Ensure Worker Always Freed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Workers should still be freed when PHPCS does not run.
+
 ## [2.1.0] - 2023-04-19
 ### Added
 - Display messages for configuration errors.

--- a/src/phpcs-report/__tests__/worker-pool.spec.ts
+++ b/src/phpcs-report/__tests__/worker-pool.spec.ts
@@ -5,11 +5,11 @@ import { CancellationError } from 'vscode';
 
 jest.mock('../worker', () => {
 	return {
-		Worker: jest.fn().mockImplementation((onActiveChanged) => {
+		Worker: jest.fn().mockImplementation((onCompletion) => {
 			const obj = {
 				execute: jest.fn(),
 				isActive: false,
-				onActiveChanged,
+				onCompletion,
 			};
 
 			return obj;
@@ -42,7 +42,7 @@ describe('WorkerPool', () => {
 
 		// Change the active status and trigger the resolution.
 		mockWorker.isActive = false;
-		mockWorker.onActiveChanged(mockWorker);
+		mockWorker.onCompletion(mockWorker);
 
 		return expect(promise).resolves.toStrictEqual(
 			jest.mocked(Worker).mock.results[0].value
@@ -84,7 +84,7 @@ describe('WorkerPool', () => {
 
 		// Change the active status and trigger the resolution.
 		mockWorker.isActive = false;
-		mockWorker.onActiveChanged(mockWorker);
+		mockWorker.onCompletion(mockWorker);
 
 		try {
 			await promise;

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -173,10 +173,10 @@ describe('Worker', () => {
 		return expect(promise).rejects.toStrictEqual(new CancellationError());
 	});
 
-	it('should support active change callback', async () => {
-		const onActiveChanged = jest.fn();
+	it('should support completion callback', async () => {
+		const onCompletion = jest.fn();
 
-		const worker = new Worker(onActiveChanged);
+		const worker = new Worker(onCompletion);
 
 		const request: Request<ReportType.Diagnostic> = {
 			type: ReportType.Diagnostic,
@@ -192,8 +192,8 @@ describe('Worker', () => {
 
 		await worker.execute(request);
 
-		expect(onActiveChanged).toHaveBeenCalledTimes(2);
-		expect(onActiveChanged).toHaveBeenLastCalledWith(worker);
+		expect(onCompletion).toHaveBeenCalledTimes(1);
+		expect(onCompletion).toHaveBeenLastCalledWith(worker);
 	});
 
 	it('should support executables with spaces', async () => {

--- a/src/phpcs-report/worker-pool.ts
+++ b/src/phpcs-report/worker-pool.ts
@@ -38,7 +38,7 @@ export class WorkerPool {
 		this.workers = new Array(capacity);
 		for (let i = 0; i < capacity; ++i) {
 			this.workers[i] = new Worker((worker) =>
-				this.onWorkerActiveChange(worker)
+				this.onWorkerCompletion(worker)
 			);
 		}
 
@@ -97,11 +97,11 @@ export class WorkerPool {
 	}
 
 	/**
-	 * A callback that is executed whenever a worker's active status changes.
+	 * A callback that is executed when a worker has completed its task.
 	 *
 	 * @param {Worker} worker The worker whose status changed.
 	 */
-	private onWorkerActiveChange(worker: Worker): void {
+	private onWorkerCompletion(worker: Worker): void {
 		if (worker.isActive) {
 			return;
 		}

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -90,11 +90,16 @@ export class Worker {
 		}
 
 		return new Promise<Response<T>>((resolve, reject) => {
-			// Under certain circumstances we shouldn't bother generating a report because it will be empty.
-			if (
-				!request.options.standard ||
-				request.documentContent.length <= 0
-			) {
+			// The absolute lack of a standard indicates that the worker shouldn't run.
+			if (request.options.standard === null) {
+				this.onCompletion?.(this);
+				resolve(Response.empty(request.type));
+				return;
+			}
+
+			// We can save time by not running the worker if there is no content.
+			if (request.documentContent.length <= 0) {
+				this.onCompletion?.(this);
 				resolve(Response.empty(request.type));
 				return;
 			}

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -5,12 +5,12 @@ import { Request } from './request';
 import { ReportType, Response } from './response';
 
 /**
- * A callback to execute when a worker's active status changes.
+ * A callback to execute when the worker has completed its task.
  *
- * @callback ActiveChangedCallback
- * @param {Worker} worker The worker that had its status changed.
+ * @callback CompletionCallback
+ * @param {Worker} worker The worker that has completed its task.
  */
-type ActiveChangedCallback = (worker: Worker) => void;
+type CompletionCallback = (worker: Worker) => void;
 
 /**
  * A custom error type for those that come from PHPCS.
@@ -47,7 +47,7 @@ export class Worker {
 	/**
 	 * A callback to execute when a worker's active status changes.
 	 */
-	private readonly onActiveChanged?: ActiveChangedCallback;
+	private readonly onCompletion?: CompletionCallback;
 
 	/**
 	 * The current process if the worker is active.
@@ -69,10 +69,10 @@ export class Worker {
 	/**
 	 * Constructor.
 	 *
-	 * @param {ActiveChangedCallback} [onActiveChanged] A callback to execute when a worker's active status changes.
+	 * @param {CompletionCallback} [onCompletion] A callback to execute when a worker has completed its task.
 	 */
-	public constructor(onActiveChanged?: ActiveChangedCallback) {
-		this.onActiveChanged = onActiveChanged;
+	public constructor(onCompletion?: CompletionCallback) {
+		this.onCompletion = onCompletion;
 	}
 
 	/**
@@ -113,9 +113,6 @@ export class Worker {
 			// The requester will receive the report when it is finished.
 			this.activeProcess = this.createProcess(request, resolve, reject);
 
-			// The worker is no longer available.
-			this.onActiveChanged?.(this);
-
 			// When the process closes we should clean up the worker and prepare it for a fresh execution.
 			this.activeProcess.on('close', () => {
 				if (cancellationHandler) {
@@ -125,7 +122,7 @@ export class Worker {
 				delete this.activeProcess;
 
 				// The worker should broadcast its availability.
-				this.onActiveChanged?.(this);
+				this.onCompletion?.(this);
 			});
 		});
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

When the worker resolved early the pool was not getting
informed of the completion. We need to make sure that
it gets freed correctly so that the pool does not
get exhausted and the status does not break.

Closes #76.

### How to test the changes in this Pull Request:

1. Open a project with linting disabled.
2. Turn on automatic executable discovery but keep standard set to disabled.
3. Try linting a file, it should not hang at all.
4. Set a standard, make sure it works.
5. Clear the setting again and make sure it still doesn't work.
