### PR TITLE
Assign Excluded Files `null` Standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workers should still be freed when PHPCS does not run.
 - Clear diagnostics when exceptions are thrown while updating them.
 - Clear diagnostics on configuration changes.
+- Excluded files should be ignored earlier to avoid errors.
 
 ## [2.1.0] - 2023-04-19
 ### Added

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -334,6 +334,34 @@ describe('Configuration', () => {
 		});
 
 		describe('automatic', () => {
+			it('ignore excluded files', async () => {
+				const mockConfiguration = {
+					get: jest.fn().mockImplementation(
+						getDefaultConfiguration({
+							standard: SpecialStandardOptions.Automatic,
+							exclude: ['**/*'],
+						})
+					),
+				};
+				jest.mocked(workspace).getConfiguration.mockReturnValue(
+					mockConfiguration as never
+				);
+
+				const result = await configuration.get(mockDocument);
+
+				expect(workspace.getConfiguration).toHaveBeenCalledWith(
+					'phpCodeSniffer',
+					mockDocument
+				);
+				expect(result).toMatchObject({
+					executable: 'test.platform',
+					exclude: [
+						/^(?:(?:\/|(?:(?!(?:\/|^)\.).)*?\/)?(?!\.)(?=.)[^/]*?)$/,
+					],
+					standard: null,
+				});
+			});
+
 			it('document folder', async () => {
 				jest.mocked(workspace).fs.stat.mockImplementation((uri) => {
 					switch (uri.path) {

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -189,20 +189,6 @@ describe('DiagnosticUpdater', () => {
 		diagnosticUpdater.update(document, LintAction.Force);
 	});
 
-	it('should respect exclude patterns', () => {
-		const document = new MockTextDocument();
-		document.fileName = 'test-document';
-
-		jest.mocked(mockConfiguration).get.mockResolvedValue({
-			executable: 'phpcs-test',
-			exclude: [new RegExp('.*/file/.*')],
-			lintAction: LintAction.Change,
-			standard: 'PSR12',
-		});
-
-		return diagnosticUpdater.update(document, LintAction.Force);
-	});
-
 	it('should not update on change when configured to save', () => {
 		const document = new MockTextDocument();
 		document.fileName = 'test-document';

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -337,6 +337,7 @@ export class Configuration {
 		}
 		const standard = await this.parseStandard(
 			document,
+			exclude,
 			rawStandard,
 			config.get<string>('standardCustom'),
 			cancellationToken
@@ -356,16 +357,25 @@ export class Configuration {
 	 * can be readily given to the worker without any other parsing.
 	 *
 	 * @param {TextDocument} document The document to read.
+	 * @param {Array.<RegExp>} exclude The path exclusion rules to check.
 	 * @param {SpecialStandardOptions|string} standard The special standard option or string literal to use.
 	 * @param {string} [customStandard] The string to use with the `Custom` special standard option.
 	 * @param {CancellationToken} [cancellationToken] The optional token for cancelling the request.
 	 */
 	private async parseStandard(
 		document: TextDocument,
+		exclude: RegExp[],
 		standard: SpecialStandardOptions | string,
 		customStandard?: string,
 		cancellationToken?: CancellationToken
 	): Promise<string | null> {
+		// Linting should be disabled for documents that are excluded.
+		for (const pattern of exclude) {
+			if (pattern.test(document.uri.fsPath)) {
+				return null;
+			}
+		}
+
 		// There are some special standard options that require some parsing.
 		switch (standard) {
 			// Linting will not be performed when the standard is null.

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -111,18 +111,6 @@ export class DiagnosticUpdater extends WorkerService {
 		this.configuration
 			.get(document, cancellationToken)
 			.then((configuration) => {
-				// Check the file's path against our exclude patterns so that we don't process
-				// diagnostics for files that the user is not interested in receiving them for.
-				for (const pattern of configuration.exclude) {
-					if (pattern.test(document.uri.fsPath)) {
-						// When an open file wasn't excluded at first but becomes excluded, it will leave
-						// behind diagnostics and code actions. To avoid this, let's always clear the
-						// data for documents that are excluded from diagnostic processing.
-						this.clearDocument(document);
-						throw new UpdatePreventedError();
-					}
-				}
-
 				// Allow users to decide when the diagnostics are updated.
 				switch (lintAction) {
 					case LintAction.Change:


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

We can use the fact that a `null` standard disables linting
to make sure that excluded files are considered as such
earlier in the process.

Closes #75.

### How to test the changes in this Pull Request:

1. Add a file to the exclude list with an "Automatic" standard.
2. Make sure there is no automatic configuration file to discover.
3. Note that there should be no missing standard related errors.
