### PR TITLE
Separate Document Change & Save Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clear diagnostics when exceptions are thrown while updating them.
 - Clear diagnostics on configuration changes.
 - Excluded files should be ignored earlier to avoid errors.
+- Avoid diagnostic conflicts between file changes and saving.
 
 ## [2.1.0] - 2023-04-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ fall back to the explicit option.
 
 This array of glob patterns allows you to exclude files and folders from linting. While the extension **does** respect
 any file rules in your coding standard, this option allows you to define additional rules.
+
+### Autofix on Save
+
+ Rather than providing an option here, this extension encourages you to use the built-in VS Code `editor.formatOnSave` option:
+
+ ```json
+ {
+     "[php]": {
+         "editor.formatOnSave": true,
+         "editor.defaultFormatter": "obliviousharmony.vscode-php-codesniffer"
+     }
+ }
+ ```

--- a/src/listeners/workspace-listener.ts
+++ b/src/listeners/workspace-listener.ts
@@ -229,7 +229,7 @@ export class WorkspaceListener implements Disposable {
 
 	/**
 	 * A callback for documents being changed.
-	 * 
+	 *
 	 * @param {TextDocument} document The affected document.
 	 */
 	private onDocumentChange(document: TextDocument): void {
@@ -260,7 +260,7 @@ export class WorkspaceListener implements Disposable {
 
 	/**
 	 * A callback for documents being saved.
-	 * 
+	 *
 	 * @param {TextDocument} document The affected document.
 	 */
 	private onDocumentSave(document: TextDocument): void {


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

Previously there was a problem where document saves would squash the debounce for updates with a different event. There isn't really a reason to debounce the save handler and so I've separated the two handlers.

### How to test the changes in this Pull Request:

1. Make sure linting on save works.
2. Make sure linting on change works.
3. Make sure linting on open works.
