### PR TITLE
Loosened Some Configuration Scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- All applicable configuration options should be able to be set at the folder level.
 
 ## [2.2.0] - 2023-11-07
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
           "items": {
             "type": "string"
           },
-          "scope": "window"
+          "scope": "resource"
         },
         "phpCodeSniffer.lintAction": {
           "type": "string",
@@ -115,13 +115,13 @@
             "Uses the PSR-12 coding standard,",
             "Uses the custom standard referenced in the custom ruleset option."
           ],
-          "scope": "window"
+          "scope": "resource"
         },
         "phpCodeSniffer.standardCustom": {
           "type": "string",
           "markdownDescription": "The custom coding standard to use if `#phpCodeSniffer.standard#` is set to 'Custom'.",
           "default": "",
-          "scope": "window"
+          "scope": "resource"
         },
         "phpCodeSniffer.executable": {
           "type": "string",
@@ -138,7 +138,7 @@
           "items": {
             "type": "string"
           },
-          "scope": "window"
+          "scope": "resource"
         }
       }
     },


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

I made an incorrect assumption that `"window"` applied to each individual folder in a multi-root workspace. This is not true and the scope that achieves that should be `"resource"`. This PR changes the scope on some of those settings.

Closes #88.

### How to test the changes in this Pull Request:

1. Make sure that the extension still works as-is.
2. Check that the extension works in a multi-root workspace and uses the correct PHPCS and configuration.
