### PR TITLE
PHPCS Integration Composer Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # Build Artifacts
 *.vsix
+obliviousharmony-vscode-phpcs-integration-*
 extension.js
 extension.js.map
 

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ composer.json
 composer.lock
 .gitignore
 *.vsix
+obliviousharmony-vscode-phpcs-integration-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support using an `obliviousharmony/vscode-phpcs-integration` Composer package to provide
+the integration files when a new `phpCodeSniffer.autoloadPHPCSIntegration` option
+is enabled.
+
+### Removed
+- **BREAKING:** The `phpCodeSniffer.specialOptions.phpcsIntegrationPathOverride` option
+has been removed in favor of using `phpCodeSniffer.autoloadPHPCSIntegration`.
+There is no reason to set a manual asset path since the Composer package accomplishes
+the same thing with an easier-to-use configuration path.
 
 ## [2.3.0] - 2024-01-26
 ### Added
@@ -42,7 +52,8 @@ for platform-specific executables.
 - Support for execution on Windows without the use of WSL.
 
 ### Changed
-- **BREAKING:** Even if `phpCodeSniffer.autoExecutable` is enabled, the working directory given to PHPCS should always be the workspace root.
+- **BREAKING:** Even if `phpCodeSniffer.autoExecutable` is enabled, the working directory given to
+PHPCS should always be the workspace root.
 
 ### Deprecated
 - `phpCodeSniffer.executable` has been deprecated in favor of platform-specific executable options.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ any file rules in your coding standard, this option allows you to define additio
  }
  ```
 
-## Using in Containerized Development Environments
+## Using in Containerized Development Environments (`phpCodeSniffer.autoloadPHPCSIntegration`)
 
-If you are using a container for your development environment we would _strongly_ recommend using one of [VS Code's remote development extensions](https://code.visualstudio.com/docs/remote/remote-overview). However, if this is not possible, [we have provided a Composer package with the files required to integrate with PHPCS](./assets/phpcs-integration). You _must_ install these files alongside PHPCS (globally or per-project) in order for the extension to work properly. Once you have installed the package it will be used automatically instead of the files bundled with the extension.
+If you are using a container for your development environment we would _strongly_ recommend using one of [VS Code's remote development extensions](https://code.visualstudio.com/docs/remote/remote-overview). However, if this is not possible, [we have provided a Composer package with the files required to integrate with PHPCS](./assets/phpcs-integration). You _must_ install these files alongside PHPCS (globally or per-project) in order for the extension to work properly. Once you have installed the package it will be used instead of the build-in integration when `phpCodeSniffer.autoloadPHPCSIntegration` is enabled.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ any file rules in your coding standard, this option allows you to define additio
      }
  }
  ```
+
+## Using in Containerized Development Environments
+
+If you are using a container for your development environment we would _strongly_ recommend using one of [VS Code's remote development extensions](https://code.visualstudio.com/docs/remote/remote-overview). However, if this is not possible, [we have provided a Composer package with the files required to integrate with PHPCS](./assets/phpcs-integration). You _must_ install these files alongside PHPCS (globally or per-project) in order for the extension to work properly. Once you have installed the package it will be used automatically instead of the files bundled with the extension.

--- a/assets/phpcs-integration/Extension/File.php
+++ b/assets/phpcs-integration/Extension/File.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VSCode\PHP_CodeSniffer\Extension;
+namespace ObliviousHarmony\VSCodePHPCSIntegration\Extension;
 
 use PHP_CodeSniffer\Files\File as BaseFile;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -9,7 +9,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
  * A class that supports targeting specific tokens for fixes to allow for
  * tracking the edits that should be created by a single
  *
- * @property \VSCode\PHP_CodeSniffer\Extension\Fixer $fixer
+ * @property \ObliviousHarmony\VSCodePHPCSIntegration\Extension\Fixer $fixer
  */
 class File extends BaseFile
 {

--- a/assets/phpcs-integration/Extension/Fixer.php
+++ b/assets/phpcs-integration/Extension/Fixer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VSCode\PHP_CodeSniffer\Extension;
+namespace ObliviousHarmony\VSCodePHPCSIntegration\Extension;
 
 use PHP_CodeSniffer\Fixer as BaseFixer;
 

--- a/assets/phpcs-integration/Handlers/CodeAction.php
+++ b/assets/phpcs-integration/Handlers/CodeAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VSCode\PHP_CodeSniffer\Handlers;
+namespace ObliviousHarmony\VSCodePHPCSIntegration\Handlers;
 
-use VSCode\PHP_CodeSniffer\Extension\File;
+use ObliviousHarmony\VSCodePHPCSIntegration\Extension\File;
 
 /**
  * A handler for returning information about edits from PHPCS in a way

--- a/assets/phpcs-integration/Handlers/Diagnostic.php
+++ b/assets/phpcs-integration/Handlers/Diagnostic.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VSCode\PHP_CodeSniffer\Handlers;
+namespace ObliviousHarmony\VSCodePHPCSIntegration\Handlers;
 
-use VSCode\PHP_CodeSniffer\Extension\File;
+use ObliviousHarmony\VSCodePHPCSIntegration\Extension\File;
 
 /**
  * A handler for returning information from PHPCS in a way that the

--- a/assets/phpcs-integration/Handlers/Format.php
+++ b/assets/phpcs-integration/Handlers/Format.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VSCode\PHP_CodeSniffer\Handlers;
+namespace ObliviousHarmony\VSCodePHPCSIntegration\Handlers;
 
-use VSCode\PHP_CodeSniffer\Extension\File;
+use ObliviousHarmony\VSCodePHPCSIntegration\Extension\File;
 
 /**
  * A handler for formatting a document or range within a document.

--- a/assets/phpcs-integration/Handlers/Handler.php
+++ b/assets/phpcs-integration/Handlers/Handler.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace VSCode\PHP_CodeSniffer\Handlers;
+namespace ObliviousHarmony\VSCodePHPCSIntegration\Handlers;
 
-use VSCode\PHP_CodeSniffer\Extension\File;
+use ObliviousHarmony\VSCodePHPCSIntegration\Extension\File;
 
 /**
  * The interface for all PHPCS handlers.

--- a/assets/phpcs-integration/README.md
+++ b/assets/phpcs-integration/README.md
@@ -7,4 +7,4 @@ This package contains the PHP files required to integrate [PHP_CodeSniffer](http
 ## Usage
 
 The use of this package is _optional_ and is only required in cases where the `phpcs` command is not ran from the same environment as
-VS Code. For example, when running PHP in a Docker container but not using one of VS Code's remote extensions. Simply install this package alongside PHPCS (globally or per-project) and the extension will automatically use it if it is available.
+VS Code. For example, when running PHP in a Docker container but not using one of VS Code's remote extensions. Simply install this package alongside PHPCS (globally or per-project) and enable the `phpCodeSniffer.autoloadPHPCSIntegration` option to use it.

--- a/assets/phpcs-integration/README.md
+++ b/assets/phpcs-integration/README.md
@@ -1,0 +1,10 @@
+# VS Code PHP_CodeSniffer Integration Files
+
+This package contains the PHP files required to integrate [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) into [the PHP_CodeSniffer VS Code extension](https://marketplace.visualstudio.com/items?itemName=obliviousharmony.vscode-php-codesniffer).
+
+**Note: This package requires version 3.0 or newer of the VS Code extension.**
+
+## Usage
+
+The use of this package is _optional_ and is only required in cases where the `phpcs` command is not ran from the same environment as
+VS Code. For example, when running PHP in a Docker container but not using one of VS Code's remote extensions. Simply install this package alongside PHPCS (globally or per-project) and the extension will automatically use it if it is available.

--- a/assets/phpcs-integration/VSCode.php
+++ b/assets/phpcs-integration/VSCode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace VSCode\PHP_CodeSniffer;
+namespace ObliviousHarmony\VSCodePHPCSIntegration;
 
 use PHP_CodeSniffer\Files\File as BaseFile;
 use PHP_CodeSniffer\Reports\Report;
-use VSCode\PHP_CodeSniffer\Extension\File;
-use VSCode\PHP_CodeSniffer\Handlers\Handler;
+use ObliviousHarmony\VSCodePHPCSIntegration\Extension\File;
+use ObliviousHarmony\VSCodePHPCSIntegration\Handlers\Handler;
 
 /**
  * The custom report for our PHPCS integration.

--- a/assets/phpcs-integration/VSCodeIntegration.php
+++ b/assets/phpcs-integration/VSCodeIntegration.php
@@ -7,10 +7,15 @@ use PHP_CodeSniffer\Reports\Report;
 use ObliviousHarmony\VSCodePHPCSIntegration\Extension\File;
 use ObliviousHarmony\VSCodePHPCSIntegration\Handlers\Handler;
 
+// This should match the version in the `configuration.ts` file so that
+// we can provide error messaging that tells them to update the
+// Composer package containing these files.
+define('PHPCS_INTEGRATION_VERSION', '1.0.0');
+
 /**
  * The custom report for our PHPCS integration.
  */
-class VSCode implements Report
+class VSCodeIntegration implements Report
 {
     /**
      * Constructor.
@@ -44,6 +49,15 @@ class VSCode implements Report
 
         // We use an environment variable to pass input to the reports.
         $input = $this->getVSCodeInput();
+
+        // Make sure that we are running the correct version of the integration package.
+        if ($input->version !== PHPCS_INTEGRATION_VERSION) {
+            $errorMessage = 'The extension expected version '
+            . PHPCS_INTEGRATION_VERSION
+            . ' of the integration files. Current Version: '
+            . $input->version . PHP_EOL;
+            throw new \InvalidArgumentException($errorMessage);
+        }
 
         // Use the handler to process the report.
         $handler = $this->getHandler($input->type);
@@ -90,7 +104,7 @@ class VSCode implements Report
     protected function getHandler($reportType)
     {
         // Find the handler class file that should power this report.
-        $report = '\\VSCode\\PHP_CodeSniffer\\Handlers\\' . $reportType;
+        $report = '\\ObliviousHarmony\\VSCodePHPCSIntegration\\Handlers\\' . $reportType;
         if (!\class_exists($report)) {
             throw new \InvalidArgumentException('Handler "' . $report . '" could be found');
         }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,41 @@
 {
+    "name": "obliviousharmony/vscode-phpcs-integration",
+    "description": "The custom PHPCS integration for the obliviousharmony.vscode-php-codesniffer VS Code extension.",
+	"version": "1.0.0",
+    "homepage": "https://github.com/ObliviousHarmony/vscode-php-codesniffer",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Christopher Allford",
+            "homepage": "https://github.com/ObliviousHarmony"
+        }
+    ],
+    "keywords": [
+        "phpcs",
+        "phpcbf",
+        "vscode",
+        "vscode-extension",
+        "vscode-phpcs",
+        "vscode-phpcbf"
+    ],
+    "readme": "assets/phpcs-integration/README.md",
+    "archive": {
+        "exclude": [
+            "*",
+            "!/composer.json",
+            "!/LICENSE.txt",
+            "!/assets/phpcs-integration"
+        ]
+    },
+	"prefer-stable": true,
+	"minimum-stability": "dev",
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "ObliviousHarmony\\VSCodePHPCSIntegration\\": "assets/phpcs-integration"
+        }
     },
     "scripts": {
         "lint": "phpcs --standard=psr12 -sp assets",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Brings PHPCS support to VS Code.",
   "version": "2.3.0",
   "license": "GPL-2.0-or-later",
-  "author": "Christopher Allford",
+  "author": "Christopher Allford (https://github.com/ObliviousHarmony)",
   "repository": {
     "type": "git",
     "url": "https://github.com/ObliviousHarmony/vscode-php-codesniffer.git"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
           "default": false,
           "scope": "resource"
         },
+        "phpCodeSniffer.autoloadPHPCSIntegration": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Whether or not the PHPCS integration files are available through the autoloader. This should only be enabled when the integration files are provided via Composer.",
+          "scope": "resource"
+        },
         "phpCodeSniffer.exec.linux": {
           "type": "string",
           "markdownDescription": "The path to the PHPCS executable we want to use on Linux when `#phpCodeSniffer.autoExecutable#` is disabled or unable to find one.",
@@ -134,12 +140,7 @@
           "type": "object",
           "description": "An object of special options for the extension that serve more narrow use-cases.",
           "default": {},
-          "properties": {
-            "phpcsIntegrationPathOverride": {
-              "type": "string",
-              "description": "Overrides the path to the directory that contains the extension's PHPCS integration."
-            }
-          },
+          "properties": {},
           "additionalProperties": false,
           "scope": "resource"
         },

--- a/src/phpcs-report/__tests__/worker-integration.test.ts
+++ b/src/phpcs-report/__tests__/worker-integration.test.ts
@@ -53,6 +53,7 @@ describe('Worker/WorkerPool Integration', () => {
 				options: {
 					executable: phpcsPath,
 					standard: 'PSR12',
+					autoloadPHPCSIntegration: false,
 				},
 				data: null,
 			};
@@ -81,6 +82,7 @@ describe('Worker/WorkerPool Integration', () => {
 				options: {
 					executable: phpcsPath,
 					standard: 'PSR12',
+					autoloadPHPCSIntegration: false,
 				},
 				data: null,
 			};

--- a/src/phpcs-report/__tests__/worker-integration.test.ts
+++ b/src/phpcs-report/__tests__/worker-integration.test.ts
@@ -8,18 +8,18 @@ import { MockCancellationToken } from '../../__mocks__/vscode';
 
 // We need to mock the report files because Webpack is being used to bundle them.
 describe('Worker/WorkerPool Integration', () => {
-	let phpcsIntegrationPath: string;
 	let phpcsPath: string;
 
 	beforeAll(() => {
-		phpcsIntegrationPath = resolvePath(
+		// Make sure the test knows where the real assets are located.
+		process.env.ASSETS_PATH = resolvePath(
 			__dirname,
 			'..',
 			'..',
 			'..',
-			'assets',
-			'phpcs-integration'
+			'assets'
 		);
+
 		phpcsPath = resolvePath(
 			__dirname,
 			'..',
@@ -53,7 +53,6 @@ describe('Worker/WorkerPool Integration', () => {
 				options: {
 					executable: phpcsPath,
 					standard: 'PSR12',
-					phpcsIntegrationPath: phpcsIntegrationPath,
 				},
 				data: null,
 			};
@@ -82,7 +81,6 @@ describe('Worker/WorkerPool Integration', () => {
 				options: {
 					executable: phpcsPath,
 					standard: 'PSR12',
-					phpcsIntegrationPath: phpcsIntegrationPath,
 				},
 				data: null,
 			};

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -52,6 +52,7 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
+				autoloadPHPCSIntegration: false,
 			},
 			data: null,
 		};
@@ -74,6 +75,7 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
+				autoloadPHPCSIntegration: false,
 			},
 			data: null,
 		};
@@ -98,6 +100,7 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
+				autoloadPHPCSIntegration: false,
 			},
 			data: {
 				code: 'PSR12.Files.OpenTag.NotAlone',
@@ -138,6 +141,7 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
+				autoloadPHPCSIntegration: false,
 			},
 			data: {},
 		};
@@ -160,6 +164,7 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
+				autoloadPHPCSIntegration: false,
 			},
 			data: null,
 		};
@@ -186,6 +191,7 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
+				autoloadPHPCSIntegration: false,
 			},
 			data: null,
 		};
@@ -208,6 +214,7 @@ describe('Worker', () => {
 				// Since we use custom reports, adding `-s` for sources won't break anything.
 				executable: phpcsPath + ' -s',
 				standard: 'PSR12',
+				autoloadPHPCSIntegration: false,
 			},
 			data: null,
 		};

--- a/src/phpcs-report/__tests__/worker.spec.ts
+++ b/src/phpcs-report/__tests__/worker.spec.ts
@@ -8,18 +8,18 @@ import { Worker } from '../worker';
 
 // We need to mock the report files because Webpack is being used to bundle them.
 describe('Worker', () => {
-	let phpcsIntegrationPath: string;
 	let phpcsPath: string;
 
 	beforeAll(() => {
-		phpcsIntegrationPath = resolvePath(
+		// Make sure the test knows where the real assets are located.
+		process.env.ASSETS_PATH = resolvePath(
 			__dirname,
 			'..',
 			'..',
 			'..',
-			'assets',
-			'phpcs-integration'
+			'assets'
 		);
+
 		phpcsPath = resolvePath(
 			__dirname,
 			'..',
@@ -52,7 +52,6 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
-				phpcsIntegrationPath: phpcsIntegrationPath,
 			},
 			data: null,
 		};
@@ -75,7 +74,6 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
-				phpcsIntegrationPath: phpcsIntegrationPath,
 			},
 			data: null,
 		};
@@ -100,7 +98,6 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
-				phpcsIntegrationPath: phpcsIntegrationPath,
 			},
 			data: {
 				code: 'PSR12.Files.OpenTag.NotAlone',
@@ -141,7 +138,6 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
-				phpcsIntegrationPath: phpcsIntegrationPath,
 			},
 			data: {},
 		};
@@ -164,7 +160,6 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
-				phpcsIntegrationPath: phpcsIntegrationPath,
 			},
 			data: null,
 		};
@@ -191,7 +186,6 @@ describe('Worker', () => {
 			options: {
 				executable: phpcsPath,
 				standard: 'PSR12',
-				phpcsIntegrationPath: phpcsIntegrationPath,
 			},
 			data: null,
 		};
@@ -214,7 +208,6 @@ describe('Worker', () => {
 				// Since we use custom reports, adding `-s` for sources won't break anything.
 				executable: phpcsPath + ' -s',
 				standard: 'PSR12',
-				phpcsIntegrationPath: phpcsIntegrationPath,
 			},
 			data: null,
 		};

--- a/src/phpcs-report/request.ts
+++ b/src/phpcs-report/request.ts
@@ -6,6 +6,7 @@ import { ReportType } from './response';
 export interface RequestOptions {
 	executable: string;
 	standard: string | null;
+	autoloadPHPCSIntegration: boolean;
 }
 
 /**

--- a/src/phpcs-report/request.ts
+++ b/src/phpcs-report/request.ts
@@ -6,7 +6,6 @@ import { ReportType } from './response';
 export interface RequestOptions {
 	executable: string;
 	standard: string | null;
-	phpcsIntegrationPath: string;
 }
 
 /**

--- a/src/phpcs-report/worker.ts
+++ b/src/phpcs-report/worker.ts
@@ -171,12 +171,17 @@ export class Worker {
 		resolve: (response: Response<T>) => void,
 		reject: (e?: unknown) => void
 	): ChildProcess {
+		// Figure out the path to the PHPCS integration.
+		const assetPath =
+			process.env.ASSETS_PATH || resolvePath(__dirname, 'assets');
+
 		// Prepare the arguments for our PHPCS process.
 		const processArguments = [
 			'-q', // Make sure custom configs never break our output.
 			'--report=' +
 				resolvePath(
-					request.options.phpcsIntegrationPath,
+					assetPath,
+					'phpcs-integration',
 					'VSCodeIntegration.php'
 				),
 			// We want to reserve error exit codes for actual errors in the PHPCS execution since errors/warnings are expected.

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -13,7 +13,6 @@ import { TextEncoder } from 'util';
 import {
 	Configuration,
 	LintAction,
-	SpecialOptions,
 	SpecialStandardOptions,
 } from '../configuration';
 import { WorkspaceLocator } from '../workspace-locator';
@@ -30,7 +29,6 @@ type ConfigurationType = {
 	lintAction: LintAction;
 	standard: SpecialStandardOptions | string;
 	standardCustom: string;
-	specialOptions: SpecialOptions;
 
 	// Deprecated Options
 	executable: string | null;
@@ -61,8 +59,6 @@ const getDefaultConfiguration = (overrides?: Partial<ConfigurationType>) => {
 				return SpecialStandardOptions.Disabled;
 			case 'standardCustom':
 				return '';
-			case 'specialOptions':
-				return {};
 
 			// Deprecated Settings
 			case 'executable':

--- a/src/services/__tests__/configuration.spec.ts
+++ b/src/services/__tests__/configuration.spec.ts
@@ -28,6 +28,7 @@ type ConfigurationType = {
 	exclude: string[];
 	lintAction: LintAction;
 	standard: SpecialStandardOptions | string;
+	autoloadPHPCSIntegration: boolean;
 	standardCustom: string;
 
 	// Deprecated Options
@@ -46,6 +47,8 @@ const getDefaultConfiguration = (overrides?: Partial<ConfigurationType>) => {
 
 		switch (key) {
 			case 'autoExecutable':
+				return false;
+			case 'autoloadPHPCSIntegration':
 				return false;
 			case 'exec.linux':
 			case 'exec.osx':

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -44,7 +44,6 @@ jest.mock('../../types', () => {
 });
 
 describe('DiagnosticUpdater', () => {
-	let phpcsIntegrationPath: string;
 	let mockLogger: Logger;
 	let mockWorkspaceLocator: WorkspaceLocator;
 	let mockConfiguration: Configuration;
@@ -55,15 +54,15 @@ describe('DiagnosticUpdater', () => {
 	let diagnosticUpdater: DiagnosticUpdater;
 
 	beforeEach(() => {
-		phpcsIntegrationPath = resolvePath(
+		// Make sure the test knows where the real assets are located.
+		process.env.ASSETS_PATH = resolvePath(
 			__dirname,
 			'..',
 			'..',
 			'..',
-			'..',
-			'assets',
-			'phpcs-integration'
+			'assets'
 		);
+
 		mockLogger = new Logger(window);
 		mockWorkspaceLocator = new WorkspaceLocator(workspace);
 		mockConfiguration = new Configuration(workspace, mockWorkspaceLocator);
@@ -105,7 +104,6 @@ describe('DiagnosticUpdater', () => {
 			exclude: [],
 			lintAction: LintAction.Change,
 			standard: 'PSR12',
-			phpcsIntegrationPath: phpcsIntegrationPath,
 		});
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
@@ -114,7 +112,6 @@ describe('DiagnosticUpdater', () => {
 				options: {
 					executable: 'phpcs-test',
 					standard: 'PSR12',
-					phpcsIntegrationPath: phpcsIntegrationPath,
 				},
 			});
 
@@ -169,7 +166,6 @@ describe('DiagnosticUpdater', () => {
 			exclude: [],
 			lintAction: LintAction.Change,
 			standard: 'PSR12',
-			phpcsIntegrationPath: phpcsIntegrationPath,
 		});
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
@@ -178,7 +174,6 @@ describe('DiagnosticUpdater', () => {
 				options: {
 					executable: 'phpcs-test',
 					standard: 'PSR12',
-					phpcsIntegrationPath: phpcsIntegrationPath,
 				},
 			});
 
@@ -203,7 +198,6 @@ describe('DiagnosticUpdater', () => {
 			exclude: [],
 			lintAction: LintAction.Save,
 			standard: 'PSR12',
-			phpcsIntegrationPath: phpcsIntegrationPath,
 		});
 
 		return diagnosticUpdater.update(document, LintAction.Change);

--- a/src/services/__tests__/diagnostic-updater.spec.ts
+++ b/src/services/__tests__/diagnostic-updater.spec.ts
@@ -104,6 +104,7 @@ describe('DiagnosticUpdater', () => {
 			exclude: [],
 			lintAction: LintAction.Change,
 			standard: 'PSR12',
+			autoloadPHPCSIntegration: false,
 		});
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
@@ -112,6 +113,7 @@ describe('DiagnosticUpdater', () => {
 				options: {
 					executable: 'phpcs-test',
 					standard: 'PSR12',
+					autoloadPHPCSIntegration: false,
 				},
 			});
 
@@ -166,6 +168,7 @@ describe('DiagnosticUpdater', () => {
 			exclude: [],
 			lintAction: LintAction.Change,
 			standard: 'PSR12',
+			autoloadPHPCSIntegration: false,
 		});
 		jest.mocked(mockWorker).execute.mockImplementation((request) => {
 			expect(request).toMatchObject({
@@ -174,6 +177,7 @@ describe('DiagnosticUpdater', () => {
 				options: {
 					executable: 'phpcs-test',
 					standard: 'PSR12',
+					autoloadPHPCSIntegration: false,
 				},
 			});
 
@@ -198,6 +202,7 @@ describe('DiagnosticUpdater', () => {
 			exclude: [],
 			lintAction: LintAction.Save,
 			standard: 'PSR12',
+			autoloadPHPCSIntegration: false,
 		});
 
 		return diagnosticUpdater.update(document, LintAction.Change);

--- a/src/services/code-action-edit-resolver.ts
+++ b/src/services/code-action-edit-resolver.ts
@@ -73,7 +73,6 @@ export class CodeActionEditResolver extends WorkerService {
 					options: {
 						executable: config.executable,
 						standard: config.standard,
-						phpcsIntegrationPath: config.phpcsIntegrationPath,
 					},
 					data: {
 						code: diagnostic.code as string,

--- a/src/services/code-action-edit-resolver.ts
+++ b/src/services/code-action-edit-resolver.ts
@@ -73,6 +73,8 @@ export class CodeActionEditResolver extends WorkerService {
 					options: {
 						executable: config.executable,
 						standard: config.standard,
+						autoloadPHPCSIntegration:
+							config.autoloadPHPCSIntegration,
 					},
 					data: {
 						code: diagnostic.code as string,

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -13,6 +13,13 @@ import { UriMap } from '../common/uri-map';
 import { WorkspaceLocator } from './workspace-locator';
 
 /**
+ * A constant for the version of the PHPCS integration files.
+ * This should be incremented if the files are changed so
+ * that we can provide a clear error message.
+ */
+export const PHPCS_INTEGRATION_VERSION = '1.0.0';
+
+/**
  * An enum describing the special parsing values in the `phpCodeSniffer.standard` configuration.
  */
 export enum SpecialStandardOptions {

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -67,6 +67,7 @@ interface ParamsFromFilesystem {
 interface ParamsFromConfiguration {
 	autoExecutable: boolean;
 	executable: string;
+	autoloadPHPCSIntegration: boolean;
 	exclude: RegExp[];
 	lintAction: LintAction;
 	standard: string | null;
@@ -80,6 +81,12 @@ export interface DocumentConfiguration {
 	 * The executable we should use in the worker.
 	 */
 	executable: string;
+
+	/**
+	 * Whether or not the PHPCS integration files should be autoloaded. If they aren't
+	 * autoloaded then they will be loaded using an absolute path to the files.
+	 */
+	autoloadPHPCSIntegration: boolean;
 
 	/**
 	 * The patterns we should use when excluding files and folders from reports.
@@ -214,6 +221,7 @@ export class Configuration {
 		// Build and cache the document configuration to save time later.
 		config = {
 			executable: fromFilesystem.executable ?? fromConfig.executable,
+			autoloadPHPCSIntegration: fromConfig.autoloadPHPCSIntegration,
 			exclude: fromConfig.exclude,
 			lintAction: fromConfig.lintAction,
 			standard: fromConfig.standard,
@@ -262,6 +270,16 @@ export class Configuration {
 		if (autoExecutable === undefined) {
 			throw new ConfigurationError(
 				'autoExecutable',
+				'Value must be a boolean.'
+			);
+		}
+
+		const autoloadPHPCSIntegration = config.get<boolean>(
+			'autoloadPHPCSIntegration'
+		);
+		if (autoloadPHPCSIntegration === undefined) {
+			throw new ConfigurationError(
+				'autoloadPHPCSIntegration',
 				'Value must be a boolean.'
 			);
 		}
@@ -352,6 +370,7 @@ export class Configuration {
 
 		return {
 			autoExecutable,
+			autoloadPHPCSIntegration,
 			executable,
 			exclude,
 			lintAction,

--- a/src/services/configuration.ts
+++ b/src/services/configuration.ts
@@ -1,4 +1,3 @@
-import { resolve as resolvePath } from 'path';
 import { TextDecoder } from 'util';
 import { Minimatch } from 'minimatch';
 import {
@@ -56,16 +55,6 @@ export enum LintAction {
 }
 
 /**
- * An interface describing the narrow use-case options in the `phpCodeSniffer.specialOptions` configuration.
- */
-export interface SpecialOptions {
-	/**
-	 * An override for the path to the directory containing the extension's PHPCS integration files.
-	 */
-	phpcsIntegrationPathOverride?: string;
-}
-
-/**
  * An interface describing the configuration parameters we can read from the filesystem.
  */
 interface ParamsFromFilesystem {
@@ -81,7 +70,6 @@ interface ParamsFromConfiguration {
 	exclude: RegExp[];
 	lintAction: LintAction;
 	standard: string | null;
-	phpcsIntegrationPath: string;
 }
 
 /**
@@ -107,11 +95,6 @@ export interface DocumentConfiguration {
 	 * The standard we should use when executing reports.
 	 */
 	standard: string | null;
-
-	/**
-	 * The path to the PHPCS integration files.
-	 */
-	phpcsIntegrationPath: string;
 }
 
 /**
@@ -234,7 +217,6 @@ export class Configuration {
 			exclude: fromConfig.exclude,
 			lintAction: fromConfig.lintAction,
 			standard: fromConfig.standard,
-			phpcsIntegrationPath: fromConfig.phpcsIntegrationPath,
 		};
 		this.cache.set(document.uri, config);
 
@@ -368,35 +350,12 @@ export class Configuration {
 			cancellationToken
 		);
 
-		const specialOptions = config.get<SpecialOptions>('specialOptions');
-		if (specialOptions === undefined) {
-			throw new ConfigurationError(
-				'specialOptions',
-				'Value must be an object.'
-			);
-		}
-
-		// Use the default integration path unless overridden.
-		let phpcsIntegrationPath: string;
-		if (specialOptions.phpcsIntegrationPathOverride) {
-			phpcsIntegrationPath = specialOptions.phpcsIntegrationPathOverride;
-		} else {
-			// Keep in mind that after bundling the integration files will be in a different location
-			// than they are in development and we need to resolve the correct path.
-			phpcsIntegrationPath = resolvePath(
-				__dirname,
-				'assets',
-				'phpcs-integration'
-			);
-		}
-
 		return {
 			autoExecutable,
 			executable,
 			exclude,
 			lintAction,
 			standard,
-			phpcsIntegrationPath,
 		};
 	}
 

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -110,12 +110,12 @@ export class DiagnosticUpdater extends WorkerService {
 
 		this.configuration
 			.get(document, cancellationToken)
-			.then((configuration) => {
+			.then((config) => {
 				// Allow users to decide when the diagnostics are updated.
 				switch (lintAction) {
 					case LintAction.Change:
 						// Allow users to restrict updates to explicit save actions.
-						if (configuration.lintAction === LintAction.Save) {
+						if (config.lintAction === LintAction.Save) {
 							throw new UpdatePreventedError();
 						}
 
@@ -123,7 +123,7 @@ export class DiagnosticUpdater extends WorkerService {
 
 					case LintAction.Save:
 						// When linting on change, we will always have the latest diagnostics, and don't need to update.
-						if (configuration.lintAction === LintAction.Change) {
+						if (config.lintAction === LintAction.Change) {
 							throw new UpdatePreventedError();
 						}
 						break;
@@ -147,8 +147,10 @@ export class DiagnosticUpdater extends WorkerService {
 							documentPath: document.uri.fsPath,
 							documentContent: document.getText(),
 							options: {
-								executable: configuration.executable,
-								standard: configuration.standard,
+								executable: config.executable,
+								standard: config.standard,
+								autoloadPHPCSIntegration:
+									config.autoloadPHPCSIntegration,
 							},
 							data: null,
 						};

--- a/src/services/diagnostic-updater.ts
+++ b/src/services/diagnostic-updater.ts
@@ -110,12 +110,12 @@ export class DiagnosticUpdater extends WorkerService {
 
 		this.configuration
 			.get(document, cancellationToken)
-			.then((config) => {
+			.then((configuration) => {
 				// Allow users to decide when the diagnostics are updated.
 				switch (lintAction) {
 					case LintAction.Change:
 						// Allow users to restrict updates to explicit save actions.
-						if (config.lintAction === LintAction.Save) {
+						if (configuration.lintAction === LintAction.Save) {
 							throw new UpdatePreventedError();
 						}
 
@@ -123,7 +123,7 @@ export class DiagnosticUpdater extends WorkerService {
 
 					case LintAction.Save:
 						// When linting on change, we will always have the latest diagnostics, and don't need to update.
-						if (config.lintAction === LintAction.Change) {
+						if (configuration.lintAction === LintAction.Change) {
 							throw new UpdatePreventedError();
 						}
 						break;
@@ -147,10 +147,8 @@ export class DiagnosticUpdater extends WorkerService {
 							documentPath: document.uri.fsPath,
 							documentContent: document.getText(),
 							options: {
-								executable: config.executable,
-								standard: config.standard,
-								phpcsIntegrationPath:
-									config.phpcsIntegrationPath,
+								executable: configuration.executable,
+								standard: configuration.standard,
 							},
 							data: null,
 						};

--- a/src/services/document-formatter.ts
+++ b/src/services/document-formatter.ts
@@ -75,6 +75,8 @@ export class DocumentFormatter extends WorkerService {
 					options: {
 						executable: config.executable,
 						standard: config.standard,
+						autoloadPHPCSIntegration:
+							config.autoloadPHPCSIntegration,
 					},
 					data: data,
 				};

--- a/src/services/document-formatter.ts
+++ b/src/services/document-formatter.ts
@@ -75,7 +75,6 @@ export class DocumentFormatter extends WorkerService {
 					options: {
 						executable: config.executable,
 						standard: config.standard,
-						phpcsIntegrationPath: config.phpcsIntegrationPath,
 					},
 					data: data,
 				};


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked for duplicate [PRs](../../pulls)?
* [x] Have you added an entry to the [CHANGELOG.md](CHANGELOG.md) file's [Unreleased] section?

### Changes proposed in this Pull Request:

This pull request sets up a Composer package for the integration files and adds a new configuration option to make it possible to use it instead of the integrated reports. This is useful for cases where the path to the report files from the extension are not available. This is primarily the case when using a Docker environment but not using a remote extension.

### How to test the changes in this Pull Request:

1. Enable the `phpCodeSniffer.autoloadPHPCSIntegration` setting. It should give an error about a missing report.
2. Add a `path` repository to a `composer.json` file in a project you want to test against.
3. `composer require -D "obliviousharmony/vscode-phpcs-integration"="*"`
4. Make sure that the extension now works
5. Disable the setting and confirm it works.
6. Remove the package and confirm it works.
